### PR TITLE
nesting specs correctly

### DIFF
--- a/definitions/artifacts/gcp-pubsub-topic.json
+++ b/definitions/artifacts/gcp-pubsub-topic.json
@@ -35,14 +35,14 @@
           "$ref": "../types/gcp-security.json"
         }
       }
-    }
-  },
-  "specs": {
-    "title": "Artifact Specs",
-    "type": "object",
-    "properties": {
-      "topic": {
-        "$ref": "../specs/topic.json"
+    },
+    "specs": {
+      "title": "Artifact Specs",
+      "type": "object",
+      "properties": {
+        "topic": {
+          "$ref": "../specs/topic.json"
+        }
       }
     }
   }


### PR DESCRIPTION
When I added the security ref above, it looks like I added an additional curly brace that bumped specs _outside_ of data. I checked all the other bundles and this was the only regression. 