### PR TITLE
allow '/' in role names for things like 'read/write'

### DIFF
--- a/definitions/types/aws-security-iam.json
+++ b/definitions/types/aws-security-iam.json
@@ -5,7 +5,7 @@
   "description": "IAM Policies",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z]+$": {
+    "^[a-z\/]+$": {
       "type": "object",
       "required": [
         "policy_arn"

--- a/definitions/types/azure-security-iam.json
+++ b/definitions/types/azure-security-iam.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
   "title": "IAM",
-  "description": "IAM Roles And Conditions",
+  "description": "IAM Roles And Scopes",
   "additionalProperties": false,
   "patternProperties": {
     "^[a-z\/]+$": {

--- a/definitions/types/azure-security-iam.json
+++ b/definitions/types/azure-security-iam.json
@@ -5,7 +5,7 @@
   "description": "IAM Roles And Conditions",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z]+$": {
+    "^[a-z\/]+$": {
       "type": "object",
       "required": [
         "role",

--- a/definitions/types/gcp-security-iam.json
+++ b/definitions/types/gcp-security-iam.json
@@ -5,7 +5,7 @@
   "description": "IAM Roles And Conditions",
   "additionalProperties": false,
   "patternProperties": {
-    "^.*$": {
+    "^[a-z\/]+$": {
       "type": "object",
       "required": [
         "role"


### PR DESCRIPTION
This allows roles to have names that are lowercase letters or slashes, so `read`, `write` and `read/write` would all be allowed.