### PR TITLE
Remove required on obs blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ _must_ have the format (omit fields if not applicable):
     },
     "auditing": {
       // TBD:
-    },
-    "observability": { // REQUIRED if applicable
-      // Observability configuration this bundle created.
-      "sqsAlertingToken": "foo"
     }
   },
   "specs": {
@@ -100,10 +96,6 @@ When creating these artifacts in terraform a local block should be used to elimi
     },
     "auditing": {
       // TBD:
-    },
-    "observability": { // REQUIRED if applicable
-      // Observability configuration this bundle created.
-      "sqsAlertingToken": "foo"
     }
     "authentication": { // REQUIRED if auth is created
       "token": "foo"

--- a/definitions/artifacts/aws-vpc.json
+++ b/definitions/artifacts/aws-vpc.json
@@ -26,9 +26,6 @@
       "properties": {
         "observability": {
           "title": "Observability configuration",
-          "required": [
-            "alarm_sns_topic_arn"
-          ],
           "type": "object",
           "properties": {
             "alarm_sns_topic_arn": {

--- a/definitions/artifacts/azure-virtual-network.json
+++ b/definitions/artifacts/azure-virtual-network.json
@@ -21,15 +21,11 @@
       "title": "Artifact Data",
       "type": "object",
       "required": [
-        "infrastructure",
-        "observability"
+        "infrastructure"
       ],
       "properties": {
         "observability": {
           "title": "Observability configuration",
-          "required": [
-            "alarm_monitor_action_group_ari"
-          ],
           "type": "object",
           "properties": {
             "alarm_monitor_action_group_ari": {

--- a/definitions/artifacts/gcp-subnetwork.json
+++ b/definitions/artifacts/gcp-subnetwork.json
@@ -27,9 +27,6 @@
       "properties": {
         "observability": {
           "title": "Observability configuration",
-          "required": [
-            "alarm_notification_channel_grn"
-          ],
           "type": "object",
           "properties": {
             "alarm_notification_channel_grn": {


### PR DESCRIPTION
Removing the requirement on observability blocks this should be a backwards compat change.

VPCs & networks should still be able to produce obs. urls, but this no longer requires them.

This will allow for us to roll out cloud-by-cloud removing obs from the network bundle, and adding expecting it from `var.md_metadata`.

We'll need to loop back after all have merged and remove obs completely.