### PR TITLE
Clarifying workflows here.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,25 @@
+name: Build artifacts
+# we dont support beta channel on artdefs yet...
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download Massdriver CLI
+        uses: dsaltares/fetch-gh-release-asset@0.0.8
+        with:
+          repo: "massdriver-cloud/massdriver-cli"
+          file: "^mass-.*-linux-amd64\\.tar\\.gz$"
+          regex: true
+          token: ${{ secrets.ORGANIZATION_GITHUB_TOKEN }}
+
+      - name: Build
+        run: tar -xzf mass-*.tar.gz && export PATH=$PWD:$PATH && cd definitions/artifacts && for artifact in *; do echo ${artifact}; mass schema dereference ${artifact}; done

--- a/.github/workflows/publish-stable.yaml
+++ b/.github/workflows/publish-stable.yaml
@@ -1,4 +1,4 @@
-name: Publish bundles to Massdriver
+name: Publish artifacts to Massdriver (stable)
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish_to_massdriver:
-    name: Build and publish
+    name: Build and publish artifacts to Massdriver (stable)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,4 +24,4 @@ jobs:
       - name: Build and Publish
         run: tar -xzf mass-*.tar.gz && export PATH=$PWD:$PATH && cd definitions/artifacts && for artifact in *; do echo ${artifact}; mass schema dereference ${artifact} | mass definition publish -f -; done
         env:
-          MASSDRIVER_API_KEY: ${{ secrets.MASSDRIVER_API_KEY }}
+          MASSDRIVER_API_KEY: ${{ secrets.MASSDRIVER_STABLE_RELEASE_CHANNEL_API_KEY }}


### PR DESCRIPTION
backend doesnt support multiple orgs for artdefs yet, so just `build` on develop and `publish` on `main`