### PR TITLE
Remove obs blocks

### DIFF
--- a/definitions/artifacts/aws-vpc.json
+++ b/definitions/artifacts/aws-vpc.json
@@ -24,15 +24,6 @@
         "infrastructure"
       ],
       "properties": {
-        "observability": {
-          "title": "Observability configuration",
-          "type": "object",
-          "properties": {
-            "alarm_sns_topic_arn": {
-              "$ref": "../types/aws-arn.json"
-            }
-          }
-        },
         "infrastructure": {
           "title": "Infrastructure configuration",
           "required": [

--- a/definitions/artifacts/azure-virtual-network.json
+++ b/definitions/artifacts/azure-virtual-network.json
@@ -24,15 +24,6 @@
         "infrastructure"
       ],
       "properties": {
-        "observability": {
-          "title": "Observability configuration",
-          "type": "object",
-          "properties": {
-            "alarm_monitor_action_group_ari": {
-              "$ref": "../types/azure-resource-id.json"
-            }
-          }
-        },
         "infrastructure": {
           "title": "Infrastructure configuration",
           "required": [

--- a/definitions/artifacts/gcp-subnetwork.json
+++ b/definitions/artifacts/gcp-subnetwork.json
@@ -25,24 +25,6 @@
         "infrastructure"
       ],
       "properties": {
-        "observability": {
-          "title": "Observability configuration",
-          "type": "object",
-          "properties": {
-            "alarm_notification_channel_grn": {
-              "type": "string",
-              "title": "Alarm Notification Channel GRN",
-              "description": "Alarm Notification Channel GRN",
-              "examples": [
-                "projects/my-project/notificationChannels/0009999999999999111"
-              ],
-              "pattern": "^projects\/[a-z0-9-]+\/notificationChannels\/[0-9]+$",
-              "message": {
-                "pattern": "The provided GRN does not follow the expected pattern. See the examples for valid GRNs."
-              }
-            }
-          }
-        },
         "infrastructure": {
           "title": "Infrastructure configuration",
           "required": [


### PR DESCRIPTION
Finishing migration to per-target alarm channels.

This removes all obs from artifact definitions.

This should not be merged until after azure vnets are released to public.

Closes #40 