### PR TITLE
Set $md.name

### DIFF
--- a/definitions/artifacts/aws-dynamodb-table.json
+++ b/definitions/artifacts/aws-dynamodb-table.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/aws-dynamodb-table.json",
   "$md": {
-    "access": "public"
+    "access": "public",
+    "name": "aws-dynamodb-table"
   },
   "type": "object",
   "title": "AWS DynamoDB Table",

--- a/definitions/artifacts/aws-iam-role.json
+++ b/definitions/artifacts/aws-iam-role.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/aws-iam-role.json",
   "$md": {
     "access": "public",
     "defaultTargetConnectionGroup": "credentials",
@@ -18,7 +17,8 @@
     "dnsZones": {
       "label": "AWS Route 53",
       "cloud": "aws"
-    }
+    },
+    "name": "aws-iam-role"
   },
   "type": "object",
   "title": "AWS IAM Role",

--- a/definitions/artifacts/aws-s3-bucket.json
+++ b/definitions/artifacts/aws-s3-bucket.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/aws-s3-bucket.json",
   "$md": {
-    "access": "public"
+    "access": "public",
+    "name": "aws-s3-bucket"
   },
   "type": "object",
   "title": "AWS S3 Bucket",

--- a/definitions/artifacts/aws-vpc.json
+++ b/definitions/artifacts/aws-vpc.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/aws-vpc.json",
   "$md": {
     "access": "public",
     "defaultTargetConnectionGroup": "networking",
     "defaultTargetConnectionGroupLabel": "AWS",
     "importing": {
       "group": "networking"
-    }
+    },
+    "name": "aws-vpc"
   },
   "type": "object",
   "title": "AWS Virtual Private Cloud",

--- a/definitions/artifacts/azure-data-lake-storage.json
+++ b/definitions/artifacts/azure-data-lake-storage.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://schemas.massdriver.cloud/definitions/artifacts/azure-data-lake-storage.json",
   "$md": {
-    "access": "public"
+    "access": "public",
+    "name": "azure-data-lake-storage"
   },
   "type": "object",
   "title": "Azure Data Lake Storage",

--- a/definitions/artifacts/azure-service-principal.json
+++ b/definitions/artifacts/azure-service-principal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/azure-service-principal.json",
   "$md": {
     "access": "public",
     "defaultTargetConnectionGroup": "credentials",
@@ -14,7 +13,8 @@
     "dnsZones": {
       "label": "Azure DNS",
       "cloud": "azure"
-    }
+    },
+    "name": "azure-service-principal"
   },
   "type": "object",
   "title": "Azure Service Principal",
@@ -63,7 +63,8 @@
     "specs": {
       "title": "Artifact Specs",
       "type": "object",
-      "properties": {}
+      "properties": {
+      }
     }
   }
 }

--- a/definitions/artifacts/azure-virtual-network.json
+++ b/definitions/artifacts/azure-virtual-network.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/azure-virtual-network.json",
   "$md": {
     "access": "public",
     "defaultTargetConnectionGroup": "networking",
     "defaultTargetConnectionGroupLabel": "Azure",
     "importing": {
       "group": "networking"
-    }
+    },
+    "name": "azure-virtual-network"
   },
   "type": "object",
   "title": "Azure Virtual Network",

--- a/definitions/artifacts/draft-node.json
+++ b/definitions/artifacts/draft-node.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/draft-node.json",
   "$md": {
-    "access": "public"
+    "access": "public",
+    "name": "draft-node"
   },
   "type": "object",
   "title": "Draft Node",
@@ -36,8 +36,11 @@
     "specs": {
       "type": "object",
       "additionalProperties": false,
-      "required": [],
-      "properties": {}
+      "required": [
+
+      ],
+      "properties": {
+      }
     }
   }
 }

--- a/definitions/artifacts/elasticsearch-authentication.json
+++ b/definitions/artifacts/elasticsearch-authentication.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/elasticsearch-authentication.json",
   "$md": {
-    "access": "public"
+    "access": "public",
+    "name": "elasticsearch-authentication"
   },
   "type": "object",
   "title": "Elasticsearch Cluster",

--- a/definitions/artifacts/env-file.json
+++ b/definitions/artifacts/env-file.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/env-file.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "data"
-    }
+    },
+    "name": "env-file"
   },
   "type": "object",
   "title": "Environment Variables",
@@ -47,7 +47,8 @@
     "specs": {
       "title": "Artifact Specs",
       "type": "object",
-      "properties": {}
+      "properties": {
+      }
     }
   }
 }

--- a/definitions/artifacts/gcp-bucket-https.json
+++ b/definitions/artifacts/gcp-bucket-https.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/gcp-bucket-https.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "data"
-    }
+    },
+    "name": "gcp-bucket-https"
   },
   "type": "object",
   "title": "GCP HTTPS Bucket",

--- a/definitions/artifacts/gcp-cloud-function.json
+++ b/definitions/artifacts/gcp-cloud-function.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/gcp-cloud-function.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "data"
-    }
+    },
+    "name": "gcp-cloud-function"
   },
   "type": "object",
   "title": "GCP Cloud Function",

--- a/definitions/artifacts/gcp-firebase-authentication.json
+++ b/definitions/artifacts/gcp-firebase-authentication.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/gcp-firebase-authentication.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "data"
-    }
+    },
+    "name": "gcp-firebase-authentication"
   },
   "type": "object",
   "title": "GCP Firebase Configuration",

--- a/definitions/artifacts/gcp-global-network.json
+++ b/definitions/artifacts/gcp-global-network.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/gcp-global-network.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "networking"
-    }
+    },
+    "name": "gcp-global-network"
   },
   "type": "object",
   "title": "GCP Global Network",

--- a/definitions/artifacts/gcp-pubsub-subscription.json
+++ b/definitions/artifacts/gcp-pubsub-subscription.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/gcp-pubsub-subscription.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "data"
-    }
+    },
+    "name": "gcp-pubsub-subscription"
   },
   "type": "object",
   "title": "GCP PubSub Subscription",

--- a/definitions/artifacts/gcp-pubsub-topic.json
+++ b/definitions/artifacts/gcp-pubsub-topic.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/gcp-pubsub-topic.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "data"
-    }
+    },
+    "name": "gcp-pubsub-topic"
   },
   "type": "object",
   "title": "GCP PubSub Topic",

--- a/definitions/artifacts/gcp-service-account.json
+++ b/definitions/artifacts/gcp-service-account.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/gcp-service-account.json",
   "$md": {
     "access": "public",
     "defaultTargetConnectionGroup": "credentials",
@@ -19,7 +18,8 @@
     "dnsZones": {
       "label": "GCP Cloud DNS",
       "cloud": "gcp"
-    }
+    },
+    "name": "gcp-service-account"
   },
   "type": "object",
   "title": "GCP Service Account",

--- a/definitions/artifacts/gcp-subnetwork.json
+++ b/definitions/artifacts/gcp-subnetwork.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/gcp-subnetwork.json",
   "$md": {
     "access": "public",
     "defaultTargetConnectionGroup": "networking",
     "defaultTargetConnectionGroupLabel": "GCP",
     "importing": {
       "group": "networking"
-    }
+    },
+    "name": "gcp-subnetwork"
   },
   "type": "object",
   "title": "GCP Subnetwork",

--- a/definitions/artifacts/kafka-authentication.json
+++ b/definitions/artifacts/kafka-authentication.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/kafka-authentication.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "data"
-    }
+    },
+    "name": "kafka-authentication"
   },
   "type": "object",
   "title": "AWS MSK Cluster",

--- a/definitions/artifacts/kubernetes-cluster.json
+++ b/definitions/artifacts/kubernetes-cluster.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/kubernetes-cluster.json",
   "$md": {
     "access": "public",
     "defaultTargetConnectionGroup": "credentials",
@@ -12,7 +11,8 @@
         "template": "IyBMaXF1aWQgdGVtcGxhdGUgZm9yIGV4cG9ydGluZyBhbiBhcnRpZmFjdCB0byBrdWJlIGNvbmZpZyBZQU1MCmFwaVZlcnNpb246IHYxCmNsdXN0ZXJzOgogIC0gY2x1c3RlcjoKICAgICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IHt7IGFydGlmYWN0LmRhdGEuYXV0aGVudGljYXRpb24uY2x1c3Rlci5jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YSB9fQogICAgICBzZXJ2ZXI6IHt7IGFydGlmYWN0LmRhdGEuYXV0aGVudGljYXRpb24uY2x1c3Rlci5zZXJ2ZXIgfX0KICAgIG5hbWU6IHt7IGFydGlmYWN0LmlkIH19CmNvbnRleHRzOgogIC0gY29udGV4dDoKICAgICAgY2x1c3Rlcjoge3sgYXJ0aWZhY3QuaWQgfX0KICAgICAgdXNlcjoge3sgYXJ0aWZhY3QuaWQgfX0KICAgIG5hbWU6IHt7IGFydGlmYWN0LmlkIH19CmN1cnJlbnQtY29udGV4dDoge3sgYXJ0aWZhY3QuaWQgfX0Ka2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKICAtIG5hbWU6IHt7IGFydGlmYWN0LmlkIH19CiAgICB1c2VyOgogICAgICB0b2tlbjoge3sgYXJ0aWZhY3QuZGF0YS5hdXRoZW50aWNhdGlvbi51c2VyLnRva2VuIH19Cg==",
         "templateLang": "liquid"
       }
-    ]
+    ],
+    "name": "kubernetes-cluster"
   },
   "type": "object",
   "title": "Kubernetes Cluster",

--- a/definitions/artifacts/mongo-authentication.json
+++ b/definitions/artifacts/mongo-authentication.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/mongo-authentication.json",
   "$md": {
-    "access": "public"
+    "access": "public",
+    "name": "mongo-authentication"
   },
   "type": "object",
   "title": "mongo Cluster",

--- a/definitions/artifacts/mysql-authentication.json
+++ b/definitions/artifacts/mysql-authentication.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/mysql-authentication.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "data"
-    }
+    },
+    "name": "mysql-authentication"
   },
   "type": "object",
   "title": "MySQL Authentication",

--- a/definitions/artifacts/postgresql-authentication.json
+++ b/definitions/artifacts/postgresql-authentication.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/postgresql-authentication.json",
   "$md": {
     "access": "public",
     "importing": {
       "group": "data"
-    }
+    },
+    "name": "postgresql-authentication"
   },
   "type": "object",
   "title": "PostgreSQL Authentication",

--- a/definitions/artifacts/redis-authentication.json
+++ b/definitions/artifacts/redis-authentication.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://api.massdriver.cloud/artifact-definitions/massdriver/redis-authentication.json",
   "$md": {
-    "access": "public"
+    "access": "public",
+    "name": "redis-authentication"
   },
   "type": "object",
   "title": "Redis Cluster",

--- a/definitions/specs/azure.json
+++ b/definitions/specs/azure.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://schemas.massdriver.cloud/definitions/specs/azure.json",
   "type": "object",
   "title": "Azure Artifact Specs",
   "description": "",

--- a/definitions/specs/cache.json
+++ b/definitions/specs/cache.json
@@ -15,7 +15,6 @@
   ],
   "properties": {
     "engine": {
-      "$id": "#/properties/engine",
       "type": "string",
       "title": "Engine",
       "description": "The cache engine.",
@@ -25,7 +24,6 @@
       ]
     },
     "version": {
-      "$id": "#/properties/version",
       "type": "string",
       "title": "Version",
       "description": "The version of the engine",

--- a/definitions/specs/rdbms.json
+++ b/definitions/specs/rdbms.json
@@ -21,7 +21,6 @@
   ],
   "properties": {
     "engine": {
-      "$id": "#/properties/engine",
       "type": "string",
       "title": "Engine",
       "description": "The type of database server.",
@@ -31,7 +30,6 @@
       ]
     },
     "engine_version": {
-      "$id": "#/properties/version",
       "type": "string",
       "title": "Engine Version",
       "description": "The cloud provider's database version.",
@@ -40,7 +38,6 @@
       ]
     },
     "version": {
-      "$id": "#/properties/version",
       "type": "string",
       "title": "Version",
       "description": "The database version.",

--- a/definitions/types/azure-dfs.json
+++ b/definitions/types/azure-dfs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://schemas.massdriver.cloud/definitions/types/azure-dfs.json",
   "type": "string",
   "title": "Azure DFS",
   "description": "Azure DFS",

--- a/definitions/types/elasticsearch-authentication.json
+++ b/definitions/types/elasticsearch-authentication.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://schemas.massdriver.cloud/definitions/types/elasticsearch-authentication.json",
   "title": "Elasticsearch Authentication",
   "description": "Elasticsearch connection string",
   "additionalProperties": false,

--- a/definitions/types/mongo-authentication.json
+++ b/definitions/types/mongo-authentication.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://schemas.massdriver.cloud/definitions/types/mongo-authentication.json",
   "title": "Mongo Authentication",
   "description": "Mongo connection string",
   "additionalProperties": false,


### PR DESCRIPTION
Removing $id and setting $md.name. The API will generate the $id on publish.

We need to control the $id of the artifacts for proper linking between manifests. This sets a $md.name for the artifact definition, and the ID will be generated by the API.