### PR TITLE
Removal of AWS Credential check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     rev: v2.3.0
     hooks:
       - id: check-merge-conflict
-        args: [--allow-missing-credentials]
       - id: no-commit-to-branch
         args: [-b, main]
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     rev: v2.3.0
     hooks:
       - id: check-merge-conflict
-      - id: detect-aws-credentials
         args: [--allow-missing-credentials]
       - id: no-commit-to-branch
         args: [-b, main]


### PR DESCRIPTION
It's causing a conflict with pre-commit checks. Seems like it's searching for/requiring AWS credentials instead of alerting when they're found.