### PR TITLE
disable no commit to main check in CI

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,3 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3
+      env:
+        # this check prevents devs from commit to main.
+        # however, we don't want it to fail on commits to main in CI.
+        SKIP: no-commit-to-branch


### PR DESCRIPTION
example failure on main in CI:
https://github.com/massdriver-cloud/artifact-definitions/runs/7077855904?check_suite_focus=true