### PR TITLE
add releasing docs and make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+SHELL:=/bin/bash
+TAG=release-$(shell date +%s)
+
+
+.PHONY: release
+release:
+	  @if ! command -v gh  &> /dev/null; then echo "please install gh cli https://github.com/cli/cli#installation" && exit 1; fi
+		@if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then echo "releasing is only supported from tip of origin/main currently: $(git rev-parse origin/main). Please git checkout main && git reset --hard origin/main and try again." && exit 1; fi
+		gh release create ${TAG} --generate-notes --draft

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,16 @@
+# Releasing Massdriver Artifact Definitions
+## Branch Convention
+Only create new releases from tip of `origin/main`.
+
+## Naming Convention
+We name releases `release-${unix-timestamp-seconds}`.
+
+## From CLI
+Make sure to install the [`gh` CLI](https://github.com/cli/cli#installation).
+
+Use the convenience make target to generate the canonical release tag and generate the release notes for you:
+```bash
+make release
+```
+This will create a draft release and print a browser link to it for you to review in GH UI before manually confirming.
+This gives you the opportunity as a release author to add any additional comments to the changelog / release notes.


### PR DESCRIPTION
capturing the releasing conventions from this [slack thread](https://massdriverworkspace.slack.com/archives/C03HMFZU4UF/p1656351918477609) in some docs / automation.