### PR TITLE
allowing dashes in security iam map-keys

### DIFF
--- a/definitions/types/aws-security-iam.json
+++ b/definitions/types/aws-security-iam.json
@@ -5,7 +5,7 @@
   "description": "IAM Policies",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z\/]+$": {
+    "^[a-z\/-]+$": {
       "type": "object",
       "required": [
         "policy_arn"

--- a/definitions/types/aws-security-iam.json
+++ b/definitions/types/aws-security-iam.json
@@ -5,7 +5,7 @@
   "description": "IAM Policies",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z\/-]+$": {
+    "^[a-z-\/]+$": {
       "type": "object",
       "required": [
         "policy_arn"

--- a/definitions/types/gcp-security-iam.json
+++ b/definitions/types/gcp-security-iam.json
@@ -5,7 +5,7 @@
   "description": "IAM Roles And Conditions",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z\/]+$": {
+    "^[a-z\/-]+$": {
       "type": "object",
       "required": [
         "role"

--- a/definitions/types/gcp-security-iam.json
+++ b/definitions/types/gcp-security-iam.json
@@ -5,7 +5,7 @@
   "description": "IAM Roles And Conditions",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z\/-]+$": {
+    "^[a-z-\/]+$": {
       "type": "object",
       "required": [
         "role"


### PR DESCRIPTION
Follow up from https://github.com/massdriver-cloud/artifact-definitions/pull/59/files/5fc278810d55b0a3f345e24a50e93653abc00417#r908752210