### PR TITLE
Revert databricks workspace to use https url schema

### DIFF
--- a/definitions/artifacts/azure-databricks-workspace.json
+++ b/definitions/artifacts/azure-databricks-workspace.json
@@ -38,7 +38,7 @@
 						},
 						"url": {
 							"title": "Azure Databricks workspace URL",
-							"type": "string"
+							"$ref": "../types/https-url.json"
 						},
 						"raw_container_ari": {
 							"title": "Raw Container",


### PR DESCRIPTION
part of fixing massdriver-cloud/massdriver#1131

Wait til after https://github.com/massdriver-cloud/mckinsey-pilot/pull/18 is merged. 

This reverts commit cfab1e2379562fc90c6196d8dc904f92127b261b.