### PR TITLE
Adding resource ID to infrastructure

### DIFF
--- a/definitions/artifacts/mongo-authentication.json
+++ b/definitions/artifacts/mongo-authentication.json
@@ -28,7 +28,7 @@
               "$ref": "../types/k8s-application-infrastructure.json"
             },
             {
-              "$ref": "../types/azure-resource-id.json"
+              "$ref": "../types/azure-infrastructure-database.json"
             }
           ]
         },

--- a/definitions/artifacts/mongo-authentication.json
+++ b/definitions/artifacts/mongo-authentication.json
@@ -20,7 +20,17 @@
       ],
       "properties": {
         "infrastructure": {
-          "$ref": "../types/k8s-application-infrastructure.json"
+          "title": "Mongo Cluster Infrastructure",
+          "description": "Mongo cluster infrastructure configuration.",
+          "type": "object",
+          "oneOf": [
+            {
+              "$ref": "../types/k8s-application-infrastructure.json"
+            },
+            {
+              "$ref": "../types/azure-resource-id.json"
+            }
+          ]
         },
         "authentication": {
           "$ref": "../types/mongo-authentication.json"


### PR DESCRIPTION
Adding support to mongo artifact for `azure-resource-id.json` artifact type, which will allow the Cosmos DB artifact file use this artifact.