### PR TITLE
update aws region description

### DIFF
--- a/definitions/types/aws-region.json
+++ b/definitions/types/aws-region.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "string",
   "title": "Region",
-  "description": "Regional data center to provision in.",
+  "description": "AWS Region to provision in.",
   "examples": [
     "us-west-2"
   ],


### PR DESCRIPTION
don't mention data center in description.

perhaps this was intentional but it feel confusing.

