### PR TITLE
allow missing account number in arn for s3

### DIFF
--- a/definitions/types/aws-arn.json
+++ b/definitions/types/aws-arn.json
@@ -7,7 +7,7 @@
     "arn:aws:rds::ACCOUNT_NUMBER:db/prod",
     "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
   ],
-  "pattern": "^arn:aws:[a-zA-Z0-9._-]*:[a-zA-Z0-9._-]*:[0-9]{0,12}:[a-zA-Z0-9._-]+(?:[\/:][a-zA-Z0-9\/._-]+)?$",
+  "pattern": "^arn:aws:[a-zA-Z0-9._-]*:[a-zA-Z0-9._-]*:(?:[0-9]{12})?:[a-zA-Z0-9._-]+(?:[\/:][a-zA-Z0-9\/._-]+)?$",
   "message": {
     "pattern": "Correct format of an arn described here: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html"
   }

--- a/definitions/types/aws-arn.json
+++ b/definitions/types/aws-arn.json
@@ -7,7 +7,7 @@
     "arn:aws:rds::ACCOUNT_NUMBER:db/prod",
     "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
   ],
-  "pattern": "^arn:aws:[a-zA-Z0-9._-]*:[a-zA-Z0-9._-]*:[0-9]{12}:[a-zA-Z0-9._-]+(?:[\/:][a-zA-Z0-9\/._-]+)?$",
+  "pattern": "^arn:aws:[a-zA-Z0-9._-]*:[a-zA-Z0-9._-]*:[0-9]{0,12}:[a-zA-Z0-9._-]+(?:[\/:][a-zA-Z0-9\/._-]+)?$",
   "message": {
     "pattern": "Correct format of an arn described here: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html"
   }


### PR DESCRIPTION
S3 ARNs do not contain account ID because they are unique per region.
This can be seen in [AWS docs](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#:~:text=includes%20a%20path%3A-,arn%3Aaws%3As3%3A%3A%3Amy_corporate_bucket,-/*%0Aarn%3Aaws%3As3%3A%3A%3Amy_corporate_bucket/Development) `as arn:aws:s3:::my_corporate_bucket`
and is answered in this [SO post](https://stackoverflow.com/questions/51055432/why-does-s3-bucket-arn-not-contain-aws-account-number#:~:text=S3%20Bucket%20ARNs%20do%20not,unique%20across%20all%20accounts%2Fregions.&text=Correct.)