### PR TITLE
Development server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+.artifacts/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,21 @@
 SHELL:=/bin/bash
 TAG=release-$(shell date +%s)
 
+.PHONY: local.update local.server
+local.update:
+	@if ! command -v mass  &> /dev/null; then echo "please install massdriver cli https://github.com/massdriver-cloud/massdriver-cli" && exit 1; fi
+	@mkdir -p .artifacts
+	@rm .artifacts/*
+	@$(foreach artifact,$(wildcard definitions/artifacts/*.json),mass schema dereference $(artifact) > .artifacts/$(notdir $(basename $(artifact)));)
+	@echo "Schemas dumped to .artifacts/ folder. Run 'make local.server' to host locally"
+
+local.server: local.update
+	@if [ "$(shell docker ps -aq -f name=development-artifacts)" ]; then echo "Development server already running!"; else \
+	docker run --rm -d --name development-artifacts -p 8081:80 -v $(shell pwd)/.artifacts:/usr/share/nginx/html/artifact-definitions nginx:1.23.1; fi
+
 
 .PHONY: release
 release:
-	  @if ! command -v gh  &> /dev/null; then echo "please install gh cli https://github.com/cli/cli#installation" && exit 1; fi
-		@if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then echo "releasing is only supported from tip of origin/main currently: $(git rev-parse origin/main). Please git checkout main && git reset --hard origin/main and try again." && exit 1; fi
-		gh release create ${TAG} --generate-notes --draft
+	@if ! command -v gh  &> /dev/null; then echo "please install gh cli https://github.com/cli/cli#installation" && exit 1; fi
+	@if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then echo "releasing is only supported from tip of origin/main currently: $(git rev-parse origin/main). Please git checkout main && git reset --hard origin/main and try again." && exit 1; fi
+	gh release create ${TAG} --generate-notes --draft

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,22 @@
 SHELL:=/bin/bash
 TAG=release-$(shell date +%s)
 
-.PHONY: local.update local.server
+.PHONY: local.update local.server local.shutdown
 local.update:
 	@if ! command -v mass  &> /dev/null; then echo "please install massdriver cli https://github.com/massdriver-cloud/massdriver-cli" && exit 1; fi
 	@mkdir -p .artifacts
 	@rm .artifacts/*
 	@$(foreach artifact,$(wildcard definitions/artifacts/*.json),mass schema dereference $(artifact) > .artifacts/$(notdir $(basename $(artifact)));)
-	@echo "Schemas dumped to .artifacts/ folder. Run 'make local.server' to host locally"
+	@echo "Schemas dumped to .artifacts/ folder."
 
 local.server: local.update
 	@if [ "$(shell docker ps -aq -f name=development-artifacts)" ]; then echo "Development server already running!"; else \
-	docker run --rm -d --name development-artifacts -p 8081:80 -v $(shell pwd)/.artifacts:/usr/share/nginx/html/artifact-definitions nginx:1.23.1; fi
+	docker run --rm -d --name development-artifacts -p 8081:80 -v $(shell pwd)/.artifacts:/usr/share/nginx/html/artifact-definitions nginx:1.23.1 &> /dev/null; \
+	echo "Development server running! Set MASSDRIVER_URL=http://localhost:8081 to have the CLI pull artifact definitions from this server"; fi
+
+local.shutdown:
+	@if [ ! "$(shell docker ps -aq -f name=development-artifacts)" ]; then echo "Development server not running."; else \
+	docker stop development-artifacts &> /dev/null; echo "Development server shutdown!"; fi
 
 
 .PHONY: release

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Install the pre-commit to ensure our json is pretty and our json schemas valid i
 pre-commit install
 ```
 
+### Local Server
+You can run `make local.server` to run a local nginx server which hosts the artifacts in a way that the [Massdriver CLI](https://github.com/massdriver-cloud/massdriver-cli) can access them. This is convenient for local development of bundles using local artifact definitions.
+
+As you make changes to artifacts or types, you can run `make local.update` to regenerate the definitions hosted by the local server. If you set the `MASSDRIVER_URL` environment variable to `http://localhost:8081` then the CLI will pull artifact definitions from this local server instead of the Massdriver API.
+
 ## Artifacts
 
 Artifacts define connectable pieces of infrastructure in Massdriver. Artifacts that strictly represent infrastructure
@@ -37,9 +42,7 @@ _must_ have the format (omit fields if not applicable):
     "security": { // REQUIRED if applicable
       "policies": { // IAM policies this bundle created
         "read": "my_policy_foo",
-        "write": "my_policy_foo2",
-        "manage": "my_policy_foo3",
-        "admin": "my_policy_foo4"
+        "write": "my_policy_foo2"
       },
       "groups": {
         // Security groups this bundle created, downstream bundles will attach and set up their own security group rules.
@@ -86,9 +89,7 @@ When creating these artifacts in terraform a local block should be used to elimi
     "security": { // REQUIRED if applicable
       "policies": { // IAM policies this bundle created
         "read": "my_policy_foo",
-        "write": "my_policy_foo2",
-        "manage": "my_policy_foo3",
-        "admin": "my_policy_foo4"
+        "write": "my_policy_foo2"
       },
       "groups": {
         // Security groups this bundle created

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pre-commit install
 ### Local Server
 You can run `make local.server` to run a local nginx server which hosts the artifacts in a way that the [Massdriver CLI](https://github.com/massdriver-cloud/massdriver-cli) can access them. This is convenient for local development of bundles using local artifact definitions.
 
-As you make changes to artifacts or types, you can run `make local.update` to regenerate the definitions hosted by the local server. If you set the `MASSDRIVER_URL` environment variable to `http://localhost:8081` then the CLI will pull artifact definitions from this local server instead of the Massdriver API.
+As you make changes to artifacts or types, you can run `make local.update` to regenerate the definitions hosted by the local server. If you set the `MASSDRIVER_URL` environment variable to `http://localhost:8081` then the CLI will pull artifact definitions from this local server instead of the Massdriver API. Run `make local.shutdown` when you are done to shutdown the development server.
 
 ## Artifacts
 


### PR DESCRIPTION
closes: https://github.com/massdriver-cloud/massdriver/issues/1236

Added a development server to allow bundle developers to modify and use local artifacts during bundle development.

Depends on: https://github.com/massdriver-cloud/massdriver-cli/pull/84