### PR TITLE
Revert "Hide specs on import cloud credentials"

### DIFF
--- a/definitions/artifacts/aws-iam-role.json
+++ b/definitions/artifacts/aws-iam-role.json
@@ -47,9 +47,13 @@
       }
     },
     "specs": {
+      "title": "Artifact Specs",
       "type": "object",
-      "properties": {},
-      "default": {}
+      "properties": {
+        "aws": {
+          "$ref": "../specs/aws.json"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Reverts massdriver-cloud/artifact-definitions#110

Found a way to hide w/o removing specs.