### PR TITLE
adding ca-certificate type, optional for redis, mysql, postgresql

### DIFF
--- a/definitions/artifacts/mysql-authentication.json
+++ b/definitions/artifacts/mysql-authentication.json
@@ -78,6 +78,9 @@
             },
             "port": {
               "$ref": "../types/port.json"
+            },
+            "certificate": {
+              "$ref": "../types/ca-certificate.json"
             }
           }
         }

--- a/definitions/artifacts/postgresql-authentication.json
+++ b/definitions/artifacts/postgresql-authentication.json
@@ -81,6 +81,9 @@
             },
             "port": {
               "$ref": "../types/port.json"
+            },
+            "certificate": {
+              "$ref": "../types/ca-certificate.json"
             }
           }
         }

--- a/definitions/artifacts/redis-authentication.json
+++ b/definitions/artifacts/redis-authentication.json
@@ -57,6 +57,9 @@
             },
             "port": {
               "$ref": "../types/port.json"
+            },
+            "certificate": {
+              "$ref": "../types/ca-certificate.json"
             }
           }
         },

--- a/definitions/types/ca-certificate.json
+++ b/definitions/types/ca-certificate.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "required": [
+    "cert",
+    "create_time",
+    "expiration_time",
+    "sha1_fingerprint"
+  ],
+  "properties": {
+    "cert": {
+      "type": "string",
+      "title": "Certificate",
+      "description": "Certificate for TLS connection to Redis in PEM format"
+    },
+    "create_time": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Create Time",
+      "description": "Creation time of the CA Cert",
+      "examples": [
+        "2022-09-25T20:04:15.521636Z"
+      ]
+    },
+    "expiration_time": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Expiration Time",
+      "description": "Expiration time of the CA Cert",
+      "examples": [
+        "2032-09-22T20:04:15.161Z"
+      ]
+    },
+    "sha1_fingerprint": {
+      "type": "string",
+      "title": "SHA1 Fingerprint",
+      "description": "SHA Fingerprint of the CA Cert"
+    }
+  }
+}

--- a/definitions/types/ca-certificate.json
+++ b/definitions/types/ca-certificate.json
@@ -11,7 +11,7 @@
     "cert": {
       "type": "string",
       "title": "Certificate",
-      "description": "Certificate for TLS connection to Redis in PEM format"
+      "description": "Certificate for TLS connection in PEM format"
     },
     "create_time": {
       "type": "string",


### PR DESCRIPTION
To support BC compliance we'll need to turn on TLS for postgresql again. Once on, the client will need it and the same is true for Redis and mysql. I made this an optional field so it's backwards-compat.

resolves: https://github.com/massdriver-cloud/massdriver/issues/1435