### PR TITLE
modifying arn type to support sub resources

### DIFF
--- a/definitions/types/aws-arn.json
+++ b/definitions/types/aws-arn.json
@@ -7,7 +7,7 @@
     "arn:aws:rds::ACCOUNT_NUMBER:db/prod",
     "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
   ],
-  "pattern": "^arn:aws:[a-zA-Z0-9._-]*:[a-zA-Z0-9._-]*:(?:[0-9]{12})?:[a-zA-Z0-9._-]+(?:[\/:][a-zA-Z0-9\/._-]+)?$",
+  "pattern": "^arn:aws:[a-zA-Z0-9._-]*:[a-zA-Z0-9._-]*:(?:[0-9]{12})?:[a-zA-Z0-9._-]+(?:[/:][a-zA-Z0-9/._-]+)?(?:/[0-9-T:.]+)?$",
   "message": {
     "pattern": "Correct format of an arn described here: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html"
   }


### PR DESCRIPTION
Dyanmodb streams are sub resources of dynamodb so their ARNs are extended from the usual format.

example: arn:aws:dynamodb:us-west-2:123456:table/local-dev-dynamo-0000/stream/2022-09-30T00:48:00.733

This adds an optional capture group that supports that timestamp at the end. It was tested and working with the standard ddb arn as well.