### PR TITLE
add vpc connector to gcp-subnet art-def

### DIFF
--- a/definitions/artifacts/gcp-subnetwork.json
+++ b/definitions/artifacts/gcp-subnetwork.json
@@ -30,7 +30,8 @@
           "required": [
             "grn",
             "cidr",
-            "gcp_global_network_grn"
+            "gcp_global_network_grn",
+            "vpc_access_connector"
           ],
           "type": "object",
           "properties": {
@@ -41,6 +42,9 @@
               "$ref": "../types/cidr.json"
             },
             "gcp_global_network_grn": {
+              "$ref": "../types/gcp-grn.json"
+            },
+            "vpc_access_connector": {
               "$ref": "../types/gcp-grn.json"
             }
           }


### PR DESCRIPTION
We need a VPC connector for Cloud Run, Cloud Functions to access Redis, PostgreSQL, MySQL. They are regional resources, and each one is $14 a month, so instead of shipping w/ the serverless bundle it's cheaper to ship it with the subnet.