### PR TITLE
adding workload identity to artifact

### DIFF
--- a/definitions/types/aws-security-identity.json
+++ b/definitions/types/aws-security-identity.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "Identity",
+  "description": "AWS IAM Role",
+  "additionalProperties": false,
+  "properties": {
+    "role_arn": {
+      "title": "AWS Role ARN",
+      "description": "ARN for workload identity",
+      "$ref": "./aws-arn.json"
+    }
+  }
+}

--- a/definitions/types/aws-security-identity.json
+++ b/definitions/types/aws-security-identity.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
-  "title": "Identity",
-  "description": "AWS IAM Role",
+  "title": "Resource Identity",
+  "description": "For instances where IAM policies must be attached to a role attached to an AWS resource, for instance AWS Eventbridge to Firehose, this attribute should be used to allow the downstream to attach it's policies (Firehose) directly to the IAM role created by the upstream (Eventbridge). It is important to remember that connections in massdriver are one way, this scheme perserves the dependency relationship while allowing bundles to control the lifecycles of resources under it's management",
   "additionalProperties": false,
   "properties": {
     "role_arn": {
-      "title": "AWS Role ARN",
-      "description": "ARN for workload identity",
+      "title": "Role ARN",
+      "description": "ARN for this resources IAM Role",
       "$ref": "./aws-arn.json"
     }
   }

--- a/definitions/types/aws-security.json
+++ b/definitions/types/aws-security.json
@@ -11,6 +11,9 @@
     },
     "iam": {
       "$ref": "./aws-security-iam.json"
+    },
+    "identity": {
+      "$ref": "./aws-security-identity.json"
     }
   }
 }


### PR DESCRIPTION
First pass at identity in artifacts. With AWS there are some services that are completely governed by policy, SNS and SQS can allow another service to write to it, all it needs is an ARN of the resource. With Firehose, permissions are done on a role level. So event bridge needs to have a role and pass it forward to firehose. The Eventbridge rule and firehose target are dependent on event bridge so unless we solve two way connections, Eventbridge will have to pass a role forward and the created firehose will need to give that role permissions to write.

The other option here is to expand the IAM block to include a role_arn field. With the pattern properties this felt more intrusive than this option.

THOUGHTS?