### PR TITLE
remove enum from gcp region

### DIFF
--- a/definitions/types/gcp-region.json
+++ b/definitions/types/gcp-region.json
@@ -1,12 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "string",
-  "title": "GCP Region",
-  "description": "GCP region",
+  "title": "Region",
+  "description": "The GCP region to provision resources in.",
   "examples": [
-    "us-west2"
-  ],
-  "enum": [
     "us-east1",
     "us-east4",
     "us-west1",


### PR DESCRIPTION
We did this for AWS, handing the management of the gcp regions to Massdriver. Massdriver already has a list for gcp and we're using the dropdown almost everywhere.