### PR TITLE
Endpoint artifact for azure comm service

### DIFF
--- a/definitions/artifacts/endpoint.json
+++ b/definitions/artifacts/endpoint.json
@@ -43,16 +43,19 @@
     },
     "specs": {
       "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "data_location"
-      ],
       "properties": {
-        "data_location": {
-          "version": {
-            "type": "string",
-            "description": "Data location"
-          }
+        "cloud": {
+          "oneOf": [
+            {
+              "$ref": "../types/aws-specs.json"
+            },
+            {
+              "$ref": "../types/azure-specs.json"
+            },
+            {
+              "$ref": "../types/gcp-specs.json"
+            }
+          ]
         }
       }
     }

--- a/definitions/artifacts/endpoint.json
+++ b/definitions/artifacts/endpoint.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$md": {
+    "access": "public",
+    "name": "endpoint"
+  },
+  "type": "object",
+  "title": "Endpoint",
+  "description": "Resource endpoint URL for a given service.",
+  "additionalProperties": false,
+  "required": [
+    "data",
+    "specs"
+  ],
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": [
+        "infrastructure",
+        "authentication"
+      ],
+      "properties": {
+        "infrastructure": {
+          "title": "Cloud provider details",
+          "description": "Cloud specific resource IDs.",
+          "type": "object",
+          "oneOf": [
+            {
+              "$ref": "../types/aws-infrastructure-arn.json"
+            },
+            {
+              "$ref": "../types/azure-infrastructure-ari.json"
+            },
+            {
+              "$ref": "../types/gcp-infrastructure-name.json"
+            }
+          ]
+        },
+        "authentication": {
+          "$ref": "../types/https-url.json"
+        }
+      }
+    },
+    "specs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "data_location"
+      ],
+      "properties": {
+        "data_location": {
+          "version": {
+            "type": "string",
+            "description": "Data location"
+          }
+        }
+      }
+    }
+  }
+}

--- a/definitions/artifacts/endpoint.json
+++ b/definitions/artifacts/endpoint.json
@@ -43,21 +43,29 @@
     },
     "specs": {
       "type": "object",
-      "properties": {
-        "cloud": {
-          "oneOf": [
-            {
-              "$ref": "../types/aws-specs.json"
-            },
-            {
-              "$ref": "../types/azure-specs.json"
-            },
-            {
-              "$ref": "../types/gcp-specs.json"
+      "oneOf": [
+        {
+          "properties": {
+            "aws": {
+              "$ref": "../specs/aws.json"
             }
-          ]
+          }
+        },
+        {
+          "properties": {
+            "azure": {
+              "$ref": "../specs/azure.json"
+            }
+          }
+        },
+        {
+          "properties": {
+            "gcp": {
+              "$ref": "../specs/gcp.json"
+            }
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/definitions/artifacts/rabbitmq-authentication.json
+++ b/definitions/artifacts/rabbitmq-authentication.json
@@ -20,7 +20,7 @@
       ],
       "properties": {
         "infrastructure": {
-           "$ref": "../types/k8s-application-infrastructure.json"
+          "$ref": "../types/k8s-application-infrastructure.json"
         },
         "authentication": {
           "$ref": "../types/rabbitmq-authentication.json"


### PR DESCRIPTION
This artifact supplies the endpoint URL of a service, like Azure Communication Service, so that the customer can use the endpoint in their SDK or API, assuming nothing else is needed.