### PR TITLE
K8s taint, remove dependency on other types

### DIFF
--- a/definitions/types/k8s-node-taint.json
+++ b/definitions/types/k8s-node-taint.json
@@ -10,7 +10,7 @@
     ],
     "properties": {
         "taint_key": {
-            "$ref": "../types/k8s-resource-name.json",
+            "$ref": "https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/k8s-resource-name.json",
             "title": "Key",
             "description": "Taint Key",
             "examples": [
@@ -18,7 +18,7 @@
             ]
         },
         "taint_value": {
-            "$ref": "../types/k8s-resource-name.json",
+            "$ref": "https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/k8s-resource-name.json",
             "title": "Value",
             "description": "Taint Value",
             "examples": [

--- a/definitions/types/k8s-node-taint.json
+++ b/definitions/types/k8s-node-taint.json
@@ -10,17 +10,25 @@
     ],
     "properties": {
         "taint_key": {
-            "$ref": "https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/k8s-resource-name.json",
+            "type": "string",
             "title": "Key",
             "description": "Taint Key",
+            "pattern": "^(?:[a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])$",
+            "message": {
+                "pattern": "Name must follow RFC 1123: at most 63 characters, only lowercase alphanumeric characters or '-', and start and end with an alphanumeric character."
+            },
             "examples": [
                 "workloads"
             ]
         },
         "taint_value": {
-            "$ref": "https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/k8s-resource-name.json",
+            "type": "string",
             "title": "Value",
             "description": "Taint Value",
+            "pattern": "^(?:[a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])$",
+            "message": {
+                "pattern": "Name must follow RFC 1123: at most 63 characters, only lowercase alphanumeric characters or '-', and start and end with an alphanumeric character."
+            },
             "examples": [
                 "gpu"
             ]


### PR DESCRIPTION
~~kewl...~~

After last week's chat on [Slack](https://massdriverworkspace.slack.com/archives/C03HMFZU4UF/p1674419245537989), DRY doesn't make sense here. So the artifact-definition is now fully independent.



