### PR TITLE
Add support for regions

### DIFF
--- a/artifact-definition-metaschema.json
+++ b/artifact-definition-metaschema.json
@@ -63,6 +63,37 @@
             ]
           },
           "properties": {
+            "cloud": {
+              "type": "object",
+              "description": "Properties of the cloud supported by Massdriver. Only valid for 'credential' artifact definitions.",
+              "required": [
+                "regions"
+              ],
+              "properties": {
+                "regions": {
+                  "description": "List of regions",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "code",
+                      "name"
+                    ],
+                    "properties": {
+                      "code": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "containerRepositories": {
               "additionalProperties": false,
               "description": "Enables container repository using this artifact type for authentication.",

--- a/artifact-definition-metaschema.json
+++ b/artifact-definition-metaschema.json
@@ -70,6 +70,7 @@
                 "regions"
               ],
               "properties": {
+                "id": {"type": "string", "title": "ID", "description": "Identifier for cloud"},
                 "regions": {
                   "description": "List of regions",
                   "type": "array",

--- a/definitions/artifacts/aws-iam-role.json
+++ b/definitions/artifacts/aws-iam-role.json
@@ -10,6 +10,138 @@
     "diagram": {
       "isLinkable": false
     },
+    "cloud": {
+      "regions": [
+        {
+          "code": "us-east-2",
+          "name": "US East (Ohio)"
+        },
+        {
+          "code": "us-east-1",
+          "name": "US East (N. Virginia)"
+        },
+        {
+          "code": "us-west-1",
+          "name": "US West (N. California)"
+        },
+        {
+          "code": "us-west-2",
+          "name": "US West (Oregon)"
+        },
+        {
+          "code": "af-south-1",
+          "name": "Africa (Cape Town)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "ap-east-1",
+          "name": "Asia Pacific (Hong Kong)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "ap-south-2",
+          "name": "Asia Pacific (Hyderabad)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "ap-southeast-3",
+          "name": "Asia Pacific (Jakarta)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "ap-southeast-4",
+          "name": "Asia Pacific (Melbourne)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "ap-south-1",
+          "name": "Asia Pacific (Mumbai)"
+        },
+        {
+          "code": "ap-northeast-3",
+          "name": "Asia Pacific (Osaka)"
+        },
+        {
+          "code": "ap-northeast-2",
+          "name": "Asia Pacific (Seoul)"
+        },
+        {
+          "code": "ap-southeast-1",
+          "name": "Asia Pacific (Singapore)"
+        },
+        {
+          "code": "ap-southeast-2",
+          "name": "Asia Pacific (Sydney)"
+        },
+        {
+          "code": "ap-northeast-1",
+          "name": "Asia Pacific (Tokyo)"
+        },
+        {
+          "code": "ca-central-1",
+          "name": "Canada (Central)"
+        },
+        {
+          "code": "eu-central-1",
+          "name": "Europe (Frankfurt)"
+        },
+        {
+          "code": "eu-west-1",
+          "name": "Europe (Ireland)"
+        },
+        {
+          "code": "eu-west-2",
+          "name": "Europe (London)"
+        },
+        {
+          "code": "eu-south-1",
+          "name": "Europe (Milan)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "eu-west-3",
+          "name": "Europe (Paris)"
+        },
+        {
+          "code": "eu-south-2",
+          "name": "Europe (Spain)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "eu-north-1",
+          "name": "Europe (Stockholm)"
+        },
+        {
+          "code": "eu-central-2",
+          "name": "Europe (Zurich)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "me-south-1",
+          "name": "Middle East (Bahrain)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "me-central-1",
+          "name": "Middle East (UAE)",
+          "restrictions": "opt-in"
+        },
+        {
+          "code": "sa-east-1",
+          "name": "South America (São Paulo)"
+        },
+        {
+          "code": "us-gov-east-1",
+          "name": "AWS GovCloud (US-East)",
+          "restrictions": "by-request"
+        },
+        {
+          "code": "us-gov-west-1",
+          "name": "AWS GovCloud (US-West)",
+          "restrictions": "by-request"
+        }
+      ]
+    },
     "containerRepositories": {
       "label": "ECR",
       "cloud": "aws"

--- a/definitions/artifacts/aws-iam-role.json
+++ b/definitions/artifacts/aws-iam-role.json
@@ -11,6 +11,7 @@
       "isLinkable": false
     },
     "cloud": {
+      "id": "aws",
       "regions": [
         {
           "code": "us-east-2",


### PR DESCRIPTION
Adds support for credential types (where we house the rest of the platform/cloud integration) to specify the cloud regions that will show up in the MD GraphQL API.

This add support for the 'code', 'name' (to be used in UI labels)', and optionally 'restrictions' where we can set information like 'by-request' for Gov or 'opt-in' for opt-in regions.

We don't have this in the graph yet, wed need to add:

```gql
query supportedRegions{
  supportedRegions(cloud: "aws"){
    regions{code, name, restrictions}
  }
}
```