### PR TITLE
Add AWS ECS Cluster artifact

### DIFF
--- a/definitions/artifacts/aws-ecs-cluster.json
+++ b/definitions/artifacts/aws-ecs-cluster.json
@@ -16,11 +16,75 @@
             "title": "Artifact Data",
             "type": "object",
             "required": [
-                "infrastructure"
+                "infrastructure",
+                "capabilities",
+                "security"
             ],
             "properties": {
                 "capabilities": {
-
+                    "title": "Artifact Capabilities",
+                    "type": "object",
+                    "required": [
+                        "ingress"
+                    ],
+                    "properties": {
+                        "ingress": {
+                            "title": "Ingress",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "load-balancer-arn",
+                                    "security-group-arn",
+                                    "listeners"
+                                ],
+                                "properties": {
+                                    "load-balancer-arn": {
+                                        "$ref": "../types/aws-arn.json"
+                                    },
+                                    "security-group-arn": {
+                                        "$ref": "../types/aws-arn.json"
+                                    },
+                                    "listeners": {
+                                        "type": "array",
+                                        "title": "Listeners",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "arn",
+                                                "port",
+                                                "protocol"
+                                            ],
+                                            "properties": {
+                                                "arn": {
+                                                    "$ref": "../types/aws-arn.json"
+                                                },
+                                                "port": {
+                                                    "$ref": "../types/port.json"
+                                                },
+                                                "protocol": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "http",
+                                                        "https"
+                                                    ]
+                                                },
+                                                "domains": {
+                                                    "type": "array",
+                                                    "default": [],
+                                                    "items": {
+                                                        "type": "string",
+                                                        "pattern": "^(([a-z0-9]+\\.)+[a-z]+)$"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 },
                 "infrastructure": {
                     "title": "Infrastructure",
@@ -40,62 +104,6 @@
                 },
                 "security": {
                     "$ref": "../types/aws-security.json"
-                }
-            }
-        },
-        "capabilities": {
-            "title": "Artifact Capabilities",
-            "type": "object",
-            "properties": {
-                "ingress": {
-                    "title": "Ingress",
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": [
-                            "load-balancer-arn",
-                            "listeners"
-                        ],
-                        "properties": {
-                            "load-balancer-arn": {
-                                "$ref": "../types/aws-arn.json"
-                            },
-                            "listeners": {
-                                "type": "array",
-                                "title": "Listeners",
-                                "items": {
-                                    "type": "object",
-                                    "required": [
-                                        "arn",
-                                        "port",
-                                        "protocol"
-                                    ],
-                                    "properties": {
-                                        "arn": {
-                                            "$ref": "../types/aws-arn.json"
-                                        },
-                                        "port": {
-                                            "$ref": "../types/port.json"
-                                        },
-                                        "protocol": {
-                                            "type": "string",
-                                            "enum": [
-                                                "http",
-                                                "https"
-                                            ]
-                                        },
-                                        "domains": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string",
-                                                "pattern": "^(([a-z0-9]+\\.)+[a-z]+)$"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
                 }
             }
         },

--- a/definitions/artifacts/aws-ecs-cluster.json
+++ b/definitions/artifacts/aws-ecs-cluster.json
@@ -35,15 +35,15 @@
                             "items": {
                                 "type": "object",
                                 "required": [
-                                    "load-balancer-arn",
-                                    "security-group-arn",
+                                    "load_balancer_arn",
+                                    "security_group_arn",
                                     "listeners"
                                 ],
                                 "properties": {
-                                    "load-balancer-arn": {
+                                    "load_balancer_arn": {
                                         "$ref": "../types/aws-arn.json"
                                     },
-                                    "security-group-arn": {
+                                    "security_group_arn": {
                                         "$ref": "../types/aws-arn.json"
                                     },
                                     "listeners": {

--- a/definitions/artifacts/aws-ecs-cluster.json
+++ b/definitions/artifacts/aws-ecs-cluster.json
@@ -1,0 +1,112 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$md": {
+        "access": "public",
+        "name": "aws-ecs-cluster"
+    },
+    "type": "object",
+    "title": "AWS ECS Cluster",
+    "additionalProperties": false,
+    "required": [
+        "data",
+        "specs"
+    ],
+    "properties": {
+        "data": {
+            "title": "Artifact Data",
+            "type": "object",
+            "required": [
+                "infrastructure"
+            ],
+            "properties": {
+                "capabilities": {
+
+                },
+                "infrastructure": {
+                    "title": "Infrastructure",
+                    "type": "object",
+                    "required": [
+                        "arn",
+                        "vpc"
+                    ],
+                    "properties": {
+                        "arn": {
+                            "$ref": "../types/aws-arn.json"
+                        },
+                        "vpc": {
+                            "$ref": "./aws-vpc.json"
+                        }
+                    }
+                },
+                "security": {
+                    "$ref": "../types/aws-security.json"
+                }
+            }
+        },
+        "capabilities": {
+            "title": "Artifact Capabilities",
+            "type": "object",
+            "properties": {
+                "ingress": {
+                    "title": "Ingress",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "load-balancer-arn",
+                            "listeners"
+                        ],
+                        "properties": {
+                            "load-balancer-arn": {
+                                "$ref": "../types/aws-arn.json"
+                            },
+                            "listeners": {
+                                "type": "array",
+                                "title": "Listeners",
+                                "items": {
+                                    "type": "object",
+                                    "required": [
+                                        "arn",
+                                        "port",
+                                        "protocol"
+                                    ],
+                                    "properties": {
+                                        "arn": {
+                                            "$ref": "../types/aws-arn.json"
+                                        },
+                                        "port": {
+                                            "$ref": "../types/port.json"
+                                        },
+                                        "protocol": {
+                                            "type": "string",
+                                            "enum": [
+                                                "http",
+                                                "https"
+                                            ]
+                                        },
+                                        "domains": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "pattern": "^(([a-z0-9]+\\.)+[a-z]+)$"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "specs": {
+            "title": "Artifact Specs",
+            "type": "object",
+            "properties": {
+                "aws": {
+                    "$ref": "../specs/aws.json"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Note: Everything here is currently subject to change. This was my best effort to capture what is needed for ECS clusters and applications.

A lot to unpack here.

### VPC Artifact Forwarding
This is **not** something we want to become a common pattern. However, I think it makes sense to do it here.  An AWS ECS Cluster by itself is a **very** basic resource. It doesn't actually need a VPC connection.  However, to do anything with the cluster (like add instance pools or deploy a workload - including serverless Fargate workloads), VPC information is needed. This leaves 2 options:

1. Require both an ECS cluster **and** VPC connection on every ECS application. This begins looking very tangled and can even lead to misconfigurations where the VPC that the ECS instances are running in is different than the VPC you use to deploy the ECS application.
2. Nest the VPC artifact in the ECS artifact so the network information is carried forward and "implied" simply by connecting to ECS. This is much more intuitive to users.


### Capabilities Block

This is our first step into passing forward information about capabilities inherent to the bundle. This was discussed in in a [Slab document](https://massdriver.slab.com/posts/artifact-capabilities-rfc-5wrjnh6n) but was primarily focused on the Kubernetes use case. Doing this first in ECS uncovered some core differences between EKS and ECS - specifically the differences in ingress, domains and certificates.

The root of the issue is the difference between ALBs (layer 7) and NLBs (layer 4). An ALB (the [recommended approach](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-load-balancing.html) for ECS) handles domain association and TLS termination automatically for you. However, in EKS we use NLBs which are completely unaware of HTTP/HTTPS and act primarily as a high-throughput TCP reverse-proxy to the nginx ingress controller which is HTTP/HTTPS aware and which offloads DNS record and TLS certificate management to `external-dns` and `cert-manager`. Though technically ECS **can** do it similar to EKS, [it requires a complex Rub-Goldberg of AWS lambda, Route53 and AWS CloudMap](https://aws.amazon.com/blogs/containers/load-balancing-amazon-ecs-services-with-a-kubernetes-ingress-controller-style-approach/) - and it seems the only benefit to that added complexity would be "its similar to how EKS does it" 👎.

The moral of all this ^ is that in EKS, ingress, domains and cert-manager are all separate services with separate concerns that work together. In ECS, because of ALBs, they are all combined into one.

Here is an example of what an ECS capabilities block would look like:

```
"capabilities": {
    "ingress": [    # Note this is an array of objects
      {
        "load-balancer-arn": "arn:aws:::000000000000:loadbalancer/..."
        "listeners": [  # Array of objects (listeners)
          {
            "domains": [   # List of domains for this listener
              "www.foo.com"
            ],
            "arn": "arn:aws:::000000000000:...",
            "port": 443,
            "protocol": "https"
          }
        ],
      }
    ]
  }
```

I'll try to clarify the comments above:
#### Why is `ingress` an array of objects?:
We have have multiple ingress configurations. The most common would be having a public load balancer and a private load balancer. A single LB cannot serve both public and private traffic. The public load balancer's purpose is obvious - serving internet traffic. The internal (private) load balancer is important if there are any services **outside** the ECS cluster but **inside** the private network that need to reach services running in the ECS cluster. The only options are: hairpin the traffic through the public LB, or run an internal LB beside the public LB.  EKS has this same problem, and will likely need an "internal" ingress option as well.

#### Why is `listeners` an array of objects?:
Simply put, an ALB can have multiple listeners. Most likely there will only ever be 1: HTTPS (HTTP -> HTTPS redirect would be defaulted by us).

#### Why is domains nested in the listener instead of a top level?:
In the event of having 2 ingress objects - a public an private, as discussed earlier - each one would likely be on a separate domain. `mycompany.public` and `mycompany.internal`. As mentioned earlier, ALBs terminate the TLS for you - so we need to know which listener terminates TLS on which domain, so we can add the routing rules to the proper listener.

We can also add domains as a top-level - which would help if/when we can support contextual UI params from connections, but to the terraform the domains block is relatively useless without context of the listener.

#### This is all WAAAY too complex, we should just make an ALB for each application?:
Yep, that would be nice and make this a lot easier.  However:
* This goes against the design of ALBs and best practices by AWS. It's best we solve this problem the correct way (one ALB that can route to all of your services running in the ECS cluster)
* ALBs cost money, even if they are idle. While not expensive (~$20/mo) if you are running 10 microservices, each with internal and external load balancing thats $400 per month just idling.
* There is a relatively low quota of 50 LBs per region. While this is adjustable, any company doing microservices and preview environments will very quickly hit quota limits (this happened at a previous company without microservices or preview environments when all kubernetes services were load-balancer services).