### PR TITLE
AD Instance types

### DIFF
--- a/artifact-definition-metaschema.json
+++ b/artifact-definition-metaschema.json
@@ -99,7 +99,7 @@
                     }
                   }
                 },
-                "defeaultInstanceTypes": {
+                "defaultInstanceTypes": {
                   "type": "object",
                   "patternProperties": {
                     "^[a-zA-Z]": {

--- a/artifact-definition-metaschema.json
+++ b/artifact-definition-metaschema.json
@@ -67,10 +67,16 @@
               "type": "object",
               "description": "Properties of the cloud supported by Massdriver. Only valid for 'credential' artifact definitions.",
               "required": [
+                "id",
                 "regions"
               ],
               "properties": {
-                "id": {"type": "string", "title": "ID", "description": "Identifier for cloud"},
+                "id": {
+                  "type": "string",
+                  "title": "ID",
+                  "description": "Identifier used in queries to refer to this cloud",
+                  "pattern": "^[a-z0-9-]{2,}$"
+                },
                 "regions": {
                   "description": "List of regions",
                   "type": "array",
@@ -89,6 +95,46 @@
                       },
                       "restrictions": {
                         "type": "string"
+                      }
+                    }
+                  }
+                },
+                "defeaultInstanceTypes": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^[a-zA-Z]": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "size",
+                          "memoryGB",
+                          "vCpus",
+                          "iops"
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The instance name used by the provisioner to reference the instance type."
+                          },
+                          "size": {
+                            "type": "string",
+                            "description": "Display name for the instance if different"
+                          },
+                          "memoryGB": {
+                            "type": "integer",
+                            "description": "Memory in Gigabytes"
+                          },
+                          "vCpus": {
+                            "type": "integer",
+                            "description": "Number of available VCPUs"
+                          },
+                          "iops": {
+                            "type": "integer",
+                            "description": "Baseline I/O per second"
+                          }
+                        }
                       }
                     }
                   }

--- a/definitions/artifacts/aws-iam-role.json
+++ b/definitions/artifacts/aws-iam-role.json
@@ -141,7 +141,179 @@
           "name": "AWS GovCloud (US-West)",
           "restrictions": "by-request"
         }
-      ]
+      ],
+      "defaultInstanceTypes": {
+        "AWS.EC2": [
+          {
+            "name": "c5.large",
+            "size": "C5",
+            "memoryGB": 4,
+            "vCpus": 2,
+            "iops": 650
+          },
+          {
+            "name": "c5.xlarge",
+            "size": "C5",
+            "memoryGB": 8,
+            "vCpus": 4,
+            "iops": 1150
+          },
+          {
+            "name": "c5.2xlarge",
+            "size": "C5",
+            "memoryGB": 16,
+            "vCpus": 8,
+            "iops": 2300
+          },
+          {
+            "name": "c5.4xlarge",
+            "size": "C5",
+            "memoryGB": 16,
+            "vCpus": 32,
+            "iops": 4750
+          },
+          {
+            "name": "c5.9xlarge",
+            "size": "C5",
+            "memoryGB": 72,
+            "vCpus": 36,
+            "iops": 9500
+          },
+          {
+            "name": "c5.12xlarge",
+            "size": "C5",
+            "memoryGB": 96,
+            "vCpus": 48,
+            "iops": 9500
+          },
+          {
+            "name": "c5.18xlarge",
+            "size": "C5",
+            "memoryGB": 144,
+            "vCpus": 48,
+            "iops": 19000
+          },
+          {
+            "name": "c5.24xlarge",
+            "size": "C5",
+            "memoryGB": 192,
+            "vCpus": 96,
+            "iops": 19000
+          },
+          {
+            "name": "m5.large",
+            "size": "M5",
+            "memoryGB": 8,
+            "vCpus": 2,
+            "iops": 650
+          },
+          {
+            "name": "m5.xlarge",
+            "size": "M5",
+            "memoryGB": 16,
+            "vCpus": 4,
+            "iops": 1150
+          },
+          {
+            "name": "m5.2xlarge",
+            "size": "M5",
+            "memoryGB": 32,
+            "vCpus": 8,
+            "iops": 2300
+          },
+          {
+            "name": "m5.4xlarge",
+            "size": "M5",
+            "memoryGB": 64,
+            "vCpus": 16,
+            "iops": 4750
+          },
+          {
+            "name": "m5.8xlarge",
+            "size": "M5",
+            "memoryGB": 128,
+            "vCpus": 32,
+            "iops": 6800
+          },
+          {
+            "name": "m5.12xlarge",
+            "size": "M5",
+            "memoryGB": 192,
+            "vCpus": 48,
+            "iops": 9500
+          },
+          {
+            "name": "m5.16xlarge",
+            "size": "M5",
+            "memoryGB": 256,
+            "vCpus": 64,
+            "iops": 13600
+          },
+          {
+            "name": "m5.24xlarge",
+            "size": "M5",
+            "memoryGB": 384,
+            "vCpus": 96,
+            "iops": 19000
+          },
+          {
+            "name": "t3.small",
+            "size": "T3",
+            "memoryGB": 2,
+            "vCpus": 2,
+            "iops": 174
+          },
+          {
+            "name": "t3.medium",
+            "size": "T3",
+            "memoryGB": 4,
+            "vCpus": 2,
+            "iops": 347
+          },
+          {
+            "name": "t3.large",
+            "size": "T3",
+            "memoryGB": 8,
+            "vCpus": 2,
+            "iops": 695
+          },
+          {
+            "name": "t3.xlarge",
+            "size": "T3",
+            "memoryGB": 16,
+            "vCpus": 4,
+            "iops": 695
+          },
+          {
+            "name": "t3.2xlarge",
+            "size": "T3",
+            "memoryGB": 32,
+            "vCpus": 8,
+            "iops": 695
+          },
+          {
+            "name": "p2.xlarge",
+            "size": "P2",
+            "memoryGB": 61,
+            "vCpus": 4,
+            "iops": 750
+          },
+          {
+            "name": "p2.8xlarge",
+            "size": "P2",
+            "memoryGB": 488,
+            "vCpus": 32,
+            "iops": 5000
+          },
+          {
+            "name": "p2.16xlarge",
+            "size": "P2",
+            "memoryGB": 732,
+            "vCpus": 64,
+            "iops": 10000
+          }
+        ]
+      }
     },
     "containerRepositories": {
       "label": "ECR",

--- a/definitions/artifacts/azure-service-principal.json
+++ b/definitions/artifacts/azure-service-principal.json
@@ -14,7 +14,414 @@
       "label": "Azure DNS",
       "cloud": "azure"
     },
-    "name": "azure-service-principal"
+    "name": "azure-service-principal",
+    "cloud": {
+      "id": "azure",
+      "regions": [
+        {
+          "code": "eastus",
+          "name": "East US"
+        },
+        {
+          "code": "eastus2",
+          "name": "East US 2"
+        },
+        {
+          "code": "eastus3",
+          "name": "East US 3"
+        },
+        {
+          "code": "centralus",
+          "name": "Central US"
+        },
+        {
+          "code": "northcentralus",
+          "name": "North Central US (Single Zone)"
+        },
+        {
+          "code": "southcentralus",
+          "name": "South Central US"
+        },
+        {
+          "code": "westcentralus",
+          "name": "West Central US (Single Zone)"
+        },
+        {
+          "code": "westus",
+          "name": "West US (Single Zone)"
+        },
+        {
+          "code": "westus2",
+          "name": "West US 2"
+        },
+        {
+          "code": "westus3",
+          "name": "West US 3"
+        },
+        {
+          "code": "australiaeast",
+          "name": "Australia East"
+        },
+        {
+          "code": "brazilsouth",
+          "name": "Brazil South"
+        },
+        {
+          "code": "canadacentral",
+          "name": "Canada Central"
+        },
+        {
+          "code": "centralindia",
+          "name": "Central India"
+        },
+        {
+          "code": "eastasia",
+          "name": "East Asia"
+        },
+        {
+          "code": "francecentral",
+          "name": "France Central"
+        },
+        {
+          "code": "germanywestcentral",
+          "name": "Germany West Central"
+        },
+        {
+          "code": "japaneast",
+          "name": "Japan East"
+        },
+        {
+          "code": "koreacentral",
+          "name": "Korea Central"
+        },
+        {
+          "code": "northeurope",
+          "name": "North Europe"
+        },
+        {
+          "code": "norwayeast",
+          "name": "Norway East"
+        },
+        {
+          "code": "southafricanorth",
+          "name": "South Africa North"
+        },
+        {
+          "code": "southeastasia",
+          "name": "South East Asia"
+        },
+        {
+          "code": "uksouth",
+          "name": "UK South"
+        },
+        {
+          "code": "westeurope",
+          "name": "West Europe"
+        }
+      ],
+      "defaultInstanceTypes": {
+        "Microsoft.DBforMySQL": [
+          {
+            "name": "GP_Standard_D2ds_v4",
+            "size": "D2ds",
+            "memoryGB": 8,
+            "vCpus": 2,
+            "iops": 3200
+          },
+          {
+            "name": "GP_Standard_D4ds_v4",
+            "size": "D4ds",
+            "memoryGB": 16,
+            "vCpus": 4,
+            "iops": 6400
+          },
+          {
+            "name": "GP_Standard_D8ds_v4",
+            "size": "D8ds",
+            "memoryGB": 32,
+            "vCpus": 8,
+            "iops": 12800
+          },
+          {
+            "name": "GP_Standard_D16ds_v4",
+            "size": "D16ds",
+            "memoryGB": 64,
+            "vCpus": 16,
+            "iops": 18000
+          },
+          {
+            "name": "GP_Standard_D32ds_v4",
+            "size": "D32ds",
+            "memoryGB": 128,
+            "vCpus": 32,
+            "iops": 18000
+          },
+          {
+            "name": "GP_Standard_D48ds_v4",
+            "size": "D48ds",
+            "memoryGB": 192,
+            "vCpus": 48,
+            "iops": 18000
+          },
+          {
+            "name": "GP_Standard_D64ds_v4",
+            "size": "D64ds",
+            "memoryGB": 256,
+            "vCpus": 64,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E2ds_v4",
+            "size": "E2ds",
+            "memoryGB": 16,
+            "vCpus": 2,
+            "iops": 3200
+          },
+          {
+            "name": "MO_Standard_E4ds_v4",
+            "size": "E4ds",
+            "memoryGB": 32,
+            "vCpus": 4,
+            "iops": 6400
+          },
+          {
+            "name": "MO_Standard_E8ds_v4",
+            "size": "E8ds",
+            "memoryGB": 64,
+            "vCpus": 8,
+            "iops": 12800
+          },
+          {
+            "name": "MO_Standard_E16ds_v4",
+            "size": "E16ds",
+            "memoryGB": 128,
+            "vCpus": 16,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E32ds_v4",
+            "size": "E32ds",
+            "memoryGB": 256,
+            "vCpus": 32,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E48ds_v4",
+            "size": "E48ds",
+            "memoryGB": 384,
+            "vCpus": 48,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E64ds_v4",
+            "size": "E64ds",
+            "memoryGB": 432,
+            "vCpus": 64,
+            "iops": 18000
+          }
+        ],
+        "Microsoft.DBforPostgreSQL": [
+          {
+            "name": "GP_Standard_D2ds_v3",
+            "size": "D2s",
+            "memoryGB": 8,
+            "vCpus": 2,
+            "iops": 3200
+          },
+          {
+            "name": "GP_Standard_D4s_v3",
+            "size": "D4s",
+            "memoryGB": 16,
+            "vCpus": 4,
+            "iops": 6400
+          },
+          {
+            "name": "GP_Standard_D8s_v3",
+            "size": "D8s",
+            "memoryGB": 32,
+            "vCpus": 8,
+            "iops": 12800
+          },
+          {
+            "name": "GP_Standard_D16s_v3",
+            "size": "D16s",
+            "memoryGB": 64,
+            "vCpus": 16,
+            "iops": 18000
+          },
+          {
+            "name": "GP_Standard_D32s_v3",
+            "size": "D32s",
+            "memoryGB": 128,
+            "vCpus": 32,
+            "iops": 18000
+          },
+          {
+            "name": "GP_Standard_D48s_v3",
+            "size": "D48s",
+            "memoryGB": 192,
+            "vCpus": 48,
+            "iops": 18000
+          },
+          {
+            "name": "GP_Standard_D64s_v3",
+            "size": "D64s",
+            "memoryGB": 256,
+            "vCpus": 64,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E2s_v3",
+            "size": "E2s",
+            "memoryGB": 16,
+            "vCpus": 2,
+            "iops": 3200
+          },
+          {
+            "name": "MO_Standard_E4s_v3",
+            "size": "E4s",
+            "memoryGB": 32,
+            "vCpus": 4,
+            "iops": 6400
+          },
+          {
+            "name": "MO_Standard_E8s_v3",
+            "size": "E8s",
+            "memoryGB": 64,
+            "vCpus": 8,
+            "iops": 12800
+          },
+          {
+            "name": "MO_Standard_E16s_v3",
+            "size": "E16s",
+            "memoryGB": 128,
+            "vCpus": 16,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E32s_v3",
+            "size": "E32s",
+            "memoryGB": 256,
+            "vCpus": 32,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E48s_v3",
+            "size": "E48s",
+            "memoryGB": 384,
+            "vCpus": 48,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E64s_v3",
+            "size": "E64s",
+            "memoryGB": 432,
+            "vCpus": 64,
+            "iops": 18000
+          }
+        ],
+        "Microsoft.Compute": [
+          {
+            "name": "GP_Standard_D2ds_v4",
+            "size": "d2ds",
+            "memoryGB": 8,
+            "vCpus": 2,
+            "iops": 3200
+          },
+          {
+            "name": "GP_Standard_D4ds_v4",
+            "size": "D4ds",
+            "memoryGB": 16,
+            "vCpus": 4,
+            "iops": 6400
+          },
+          {
+            "name": "GP_Standard_D8ds_v4",
+            "size": "D8ds",
+            "memoryGB": 32,
+            "vCpus": 8,
+            "iops": 12800
+          },
+          {
+            "name": "GP_Standard_D16ds_v4",
+            "size": "D16ds",
+            "memoryGB": 64,
+            "vCpus": 16,
+            "iops": 1800
+          },
+          {
+            "name": "GP_Standard_D32ds_v4",
+            "size": "D32ds",
+            "memoryGB": 128,
+            "vCpus": 32,
+            "iops": 18000
+          },
+          {
+            "name": "GP_Standard_D48ds_v4",
+            "size": "D48ds",
+            "memoryGB": 192,
+            "vCpus": 48,
+            "iops": 18000
+          },
+          {
+            "name": "GP_Standard_D64ds_v4",
+            "size": "D64ds",
+            "memoryGB": 256,
+            "vCpus": 64,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E2ds_v4",
+            "size": "E2ds",
+            "memoryGB": 16,
+            "vCpus": 2,
+            "iops": 3200
+          },
+          {
+            "name": "MO_Standard_E4ds_v4",
+            "size": "E4ds",
+            "memoryGB": 32,
+            "vCpus": 4,
+            "iops": 6400
+          },
+          {
+            "name": "MO_Standard_E8ds_v4",
+            "size": "E8ds",
+            "memoryGB": 64,
+            "vCpus": 8,
+            "iops": 12800
+          },
+          {
+            "name": "MO_Standard_E16ds_v4",
+            "size": "E16ds",
+            "memoryGB": 128,
+            "vCpus": 16,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E32ds_v4",
+            "size": "E32ds",
+            "memoryGB": 256,
+            "vCpus": 32,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E48ds_v4",
+            "size": "E48ds",
+            "memoryGB": 384,
+            "vCpus": 48,
+            "iops": 18000
+          },
+          {
+            "name": "MO_Standard_E64ds_v4",
+            "size": "E64ds",
+            "memoryGB": 432,
+            "vCpus": 64,
+            "iops": 18000
+          }
+        ]
+      }
+    }
   },
   "type": "object",
   "title": "Azure Service Principal",
@@ -63,8 +470,7 @@
     "specs": {
       "title": "Artifact Specs",
       "type": "object",
-      "properties": {
-      }
+      "properties": {}
     }
   }
 }


### PR DESCRIPTION
Adding instance types to artifact definitions. 
- Moving all current defaults from the UI widget to the AD for azure.
- Adding region list to the azure-service-principal
- Adding default EC2 instance types to support kubernetes with RDS coming as a follow up.