### PR TITLE
creating eventbridge rule

### DIFF
--- a/definitions/artifacts/aws-eventbridge-rule.json
+++ b/definitions/artifacts/aws-eventbridge-rule.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$md": {
+        "access": "public",
+        "name": "aws-eventbridge-rule"
+    },
+    "type": "object",
+    "title": "AWS Eventbridge Rule",
+    "description": "Connection details for an Eventbridge rule. Used to create targets to consume events from the producer",
+    "additionalProperties": false,
+    "required": [
+        "data",
+        "specs"
+    ],
+    "properties": {
+        "data": {
+            "title": "Artifact Data",
+            "type": "object",
+            "required": [
+                "infrastructure"
+            ],
+            "properties": {
+                "infrastructure": {
+                    "title": "Infrastructure",
+                    "required": [
+                        "arn"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "arn": {
+                            "$ref": "../types/aws-arn.json"
+                        }
+                    }
+                },
+                "security": {
+                    "$ref": "../types/aws-security.json"
+                }
+            }
+        },
+        "specs": {
+            "title": "Artifact Specs",
+            "type": "object",
+            "properties": {
+                "aws": {
+                    "$ref": "../specs/aws.json"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
enables downstream services to subscribe to the rule and grant permissions for the rule to invoke/trigger