### PR TITLE
Remove secondary endpoint (null)

### DIFF
--- a/definitions/artifacts/azure-storage-account-blob.json
+++ b/definitions/artifacts/azure-storage-account-blob.json
@@ -26,17 +26,13 @@
           "type": "object",
           "required": [
             "ari",
-            "primary_endpoint",
-            "secondary_endpoint"
+            "endpoint"
           ],
           "properties": {
             "ari": {
               "$ref": "../types/azure-resource-id.json"
             },
-            "primary_endpoint": {
-              "$ref": "../types/azure-storage-account-endpoint.json"
-            },
-            "secondary_endpoint": {
+            "endpoint": {
               "$ref": "../types/azure-storage-account-endpoint.json"
             }
           }

--- a/definitions/artifacts/azure-storage-account-data-lake.json
+++ b/definitions/artifacts/azure-storage-account-data-lake.json
@@ -2,10 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
     "access": "public",
-    "name": "azure-data-lake-storage"
+    "name": "azure-storage-account-data-lake"
   },
   "type": "object",
-  "title": "Azure Data Lake Storage",
+  "title": "Azure Data Lake Storage Account",
   "description": "",
   "additionalProperties": false,
   "required": [
@@ -26,17 +26,13 @@
           "type": "object",
           "required": [
             "ari",
-            "primary_endpoint",
-            "secondary_endpoint"
+            "endpoint"
           ],
           "properties": {
             "ari": {
               "$ref": "../types/azure-resource-id.json"
             },
-            "primary_endpoint": {
-              "$ref": "../types/azure-storage-account-endpoint.json"
-            },
-            "secondary_endpoint": {
+            "endpoint": {
               "$ref": "../types/azure-storage-account-endpoint.json"
             }
           }


### PR DESCRIPTION
Secondary endpoint for storage accounts returning as null, artifact type expecting string. More trouble than its worth to include secondary endpoint when it only applies to failovers. Removing for now.