### PR TITLE
fix: Correct property name regex for AWS IAM policies

### DIFF
--- a/definitions/types/aws-security-iam.json
+++ b/definitions/types/aws-security-iam.json
@@ -5,7 +5,7 @@
   "description": "IAM Policies",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z_]+$": {
+    "^[a-z]+[a-z_]*[a-z]+$": {
       "type": "object",
       "required": [
         "policy_arn"

--- a/definitions/types/aws-security-iam.json
+++ b/definitions/types/aws-security-iam.json
@@ -5,7 +5,7 @@
   "description": "IAM Policies",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z-\/]+$": {
+    "^[a-z_]+$": {
       "type": "object",
       "required": [
         "policy_arn"


### PR DESCRIPTION
Replaces `-` with `_` because jq will consider `-` subtraction. Removes `/` because jq will consider it division