### PR TITLE
Add "cloud" to azure, gcp credentials

### DIFF
--- a/definitions/artifacts/azure-service-principal.json
+++ b/definitions/artifacts/azure-service-principal.json
@@ -10,6 +10,9 @@
     "diagram": {
       "isLinkable": false
     },
+    "cloud": {
+      "id": "azure"
+    },
     "dnsZones": {
       "label": "Azure DNS",
       "cloud": "azure"

--- a/definitions/artifacts/gcp-service-account.json
+++ b/definitions/artifacts/gcp-service-account.json
@@ -11,6 +11,9 @@
     "diagram": {
       "isLinkable": false
     },
+    "cloud": {
+        "id": "gcp"
+    },
     "containerRepositories": {
       "label": "GAR",
       "cloud": "gcp"


### PR DESCRIPTION
* Adds "cloud" field to azure-service-principal
* Adds "cloud" field gcp-service-account

Do these need a "regions" subfield like aws-iam-role? The use case that prompted this PR just needs the "cloud" field to exist.