### PR TITLE
Added endpoint_name

### DIFF
--- a/definitions/artifacts/aws-sagemaker-endpoint.json
+++ b/definitions/artifacts/aws-sagemaker-endpoint.json
@@ -22,12 +22,17 @@
         "infrastructure": {
           "title": "Infrastructure",
           "required": [
-            "arn"
+            "arn",
+            "endpoint_name"
           ],
           "type": "object",
           "properties": {
             "arn": {
               "$ref": "../types/aws-arn.json"
+            },
+            "endpoint_name": {
+              "title": "Endpoint Name",
+              "type": "string"
             }
           }
         },


### PR DESCRIPTION
I used `endpoint_name` to match https://sagemaker.readthedocs.io/en/stable/api/inference/predictors.html and to avoid the confusion between an `endpoint_name` and an `endpoint_invoke_url`