### PR TITLE
Update Client Secret regex

### DIFF
--- a/definitions/artifacts/azure-service-principal.json
+++ b/definitions/artifacts/azure-service-principal.json
@@ -245,9 +245,9 @@
         "client_secret": {
           "type": "string",
           "title": "Client Secret",
-          "pattern": "^((?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}).)*$",
+          "pattern": "[-_.~a-zA-Z0-9]{1,40}",
           "message": {
-            "pattern": "Not a valid Client Secret. You have likely added the client secret ID instead of the client secret value."
+            "pattern": "Not a valid Client Secret."
           }
         },
         "subscription_id": {


### PR DESCRIPTION
Remove the current regex which had a lookahead which does not work in go or rust. The new regex is based off the requirements here https://learn.microsoft.com/en-us/purview/sit-defn-azure-ad-client-secret

Fixes https://github.com/massdriver-cloud/artifact-definitions/issues/190