### PR TITLE
Remove AWS zone/cidr types

### DIFF
--- a/definitions/types/aws-subnet.json
+++ b/definitions/types/aws-subnet.json
@@ -10,12 +10,6 @@
   "properties": {
     "arn": {
       "$ref": "./aws-arn.json"
-    },
-    "cidr": {
-      "$ref": "./cidr.json"
-    },
-    "aws_zone": {
-      "$ref": "./aws-zone.json"
     }
   }
 }

--- a/definitions/types/aws-zone.json
+++ b/definitions/types/aws-zone.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "http://json-schema.org/draft-07/schema",
-  "type": "string",
-  "title": "AWS Zone",
-  "description": "AWS Availability Zone",
-  "examples": []
-}


### PR DESCRIPTION
* Removing AWS zone & cidr from AWS subnet type
* Del AWS zone type

Currently experiencing an issue where trying to deploy AWS ECS cluster expecting this artifact definition contract to be fulfilled, but having errors like this:
```
artifact validation failed: data.infrastructure.vpc.data.infrastructure.private_subnets.0.aws_zone: Invalid type. Expected: string, given: null
```