### PR TITLE
Clouds specs at wrong level :(

### DIFF
--- a/definitions/artifacts/opensearch-authentication.json
+++ b/definitions/artifacts/opensearch-authentication.json
@@ -79,6 +79,15 @@
         "opensearch"
       ],
       "properties": {
+        "aws": {
+          "$ref": "../specs/aws.json"
+        },
+        "azure": {
+          "$ref": "../specs/azure.json"
+        },
+        "gcp": {
+          "$ref": "../specs/gcp.json"
+        },
         "opensearch": {
           "type": "object",
           "title": "OpenSearch Cluster Specs",
@@ -97,15 +106,6 @@
             }
           }
         }
-      },
-      "aws": {
-        "$ref": "../specs/aws.json"
-      },
-      "azure": {
-        "$ref": "../specs/azure.json"
-      },
-      "gcp": {
-        "$ref": "../specs/gcp.json"
       }
     }
   }


### PR DESCRIPTION
{aws,gcp,azure} were outside of the `properties` keyword.