### PR TITLE
Deprecate/Replace TDC Groups and Labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,49 +76,70 @@ Our JSON Schema metaschema for artifact definitions can be found [here](https://
 
 ## $md config
 
+**Note:** We will be moving our artifact definitions to our OCI registry in the near future which will alleviate the need for 'packing' markdown and icons into the artifact definition JSON.
+
+Our JSON Schema metaschema for artifact definitions can be found [here](https://api.massdriver.cloud/json-schemas/artifact-definition.json).
+
 There is an top level `$md` field on some artifact definitions. These allow us to control how the front end treats them.
 
-```json
-{
-  "$md": {
-    "defaultTargetConnectionGroup": "credentials",
-    "defaultTargetConnectionGroupLabel": "GCP Service Account",
-    "importing": {
-      "fileUploadType": "json",
-      "fileUploadArtifactDataPath": ["data"],
-      "group": "authentication"
-    }
-  }
-}
-```
+Based on the JSON schema, here's a markdown document describing the `$md` configuration options:
+
+### $md Configuration Options
+
+The `$md` object contains configuration metadata for Massdriver artifact definitions. All artifact definitions must include this section.
+
+
+- **`name`** (string): The type name of the artifact definition. Must be unique to your organization and will be prefixed with your organization's slug. Must match pattern `^[a-z0-9-]{3,100}$`. This will be used by your bundles to refer to the types that they depend on or emit.
+
+- **`label`** (string): The display label shown in the Massdriver UI.
+
+- **`icon`** (string): Path to an icon file for this artifact type. Must be a valid URL.
+
+- **`ui`** (object): UI-specific configuration options.
+  - **`environmentDefaultGroup`** (string): Adds this artifact definition type to the 'environment default' overlay under this group in the UI.
+  - **`connectionOrientation`** (string): How to orient the artifact's connection to a bundle in the UI. Options:
+    - `"link"` (default): Line-based connections
+    - `"environmentDefault"`: Makes it the default for a given type in the entire environment
+  - **`instructions`** (array): Onboarding instructions for this artifact type. Only valid for 'credentials' artifact definitions. Each instruction object contains:
+    - `label` (string): The instruction label
+    - `content` (string): The instruction content
+
+- **`export`** (array): Export format configurations for downloading artifact data.
+  - **`templateLang`** (string, required): Template language. Currently only supports `"liquid"`
+  - **`fileFormat`** (string, required): File format. Currently only supports `"yaml"`
+  - **`template`** (string, required): Base64 encoded template for the export file
+  - **`downloadButtonText`** (string, required): Text displayed on the download button in the UI
+
+**Example:*
 
 ```json
 {
   "$md": {
-    "name": "the-artifact-name",
-    "defaultTargetConnectionGroup": "credentials",
-    "defaultTargetConnectionGroupLabel": "Kubernetes",
-    "importing": {
-      "fileUploadType": "yaml",
-      "fileUploadArtifactDataPath": ["data", "authentication"],
-      "group": "authentication"
-    }
+    "name": "aws-iam-role",
+    "label": "AWS IAM Role",
+    "icon": "https://example.com/icons/iamn.svg",
+    "ui": {
+      "environmentDefaultGroup": "credentials",
+      "connectionOrientation": "environmentDefault",
+      "instructions": [
+        {
+          "label": "Creating a role with the CLI",
+          "content": "BASE64_MARKDOWN_HERE"
+        },
+        {
+          "label": "Creating a role in the AWS Web Console",
+          "content": "BASE64_MARKDOWN_HERE"
+        }
+      ]
+    },
+    "export": [
+      {
+        "templateLang": "liquid",
+        "fileFormat": "yaml",
+        "template": "base64EncodedTemplateHere",
+        "downloadButtonText": "Title for downloadable version of artifact here"
+      }
+    ]
   }
 }
 ```
-
-* name - the name of the artifact without the organizational scope. This should be a URL safe name consisting of letters, numbers, and hyphens. It must be unique to the org it is published under.
-* _deprecated_: defaultTargetConnectionGroup - allows the artifacts of this type to be set as defaults for a Target, by omitting, it disables this artifact type as defaultable.
-* _deprecated_: defaultTargetConnectionGroupLabel - is the label to put on the section header for listing these types of artifacts
-* _deprecated_: importing.fileUploadType - allows files to be uploaded when importing an artifact. This requires that the artifact has the same structure as the file type. Generally only applicable to authentication
-* _deprecated_: importing.group - the group in onboarding and importing frontend that this artifact definition form should be grouped under.
-* _deprecated_: importing.fileUploadArtifactDataPath - the json key path to store the deserialized file into. Should be `["data"]` if not present.
-* `export` - different file formats of the artifact that can be downloaded
-  * `downloadButtonText` - download button text
-  * `templateLang` - the template to render the artifact in (currently only liquid is supported)
-  * `fileFormat` - the file extension to use when rendering
-  * `template` - the template
-* `ui.instructions` - onboarding instructions for this artifact type, only valid for 'credentials' artifact definitions.
-* `ui.environmentDefaultGroup` - adds this artifact definition type to the 'environment default' overlay under this group in the UI.
-* `ui.connectionOrientation` - how to orient the artifact's connection to a bundle in the UI. `link` will be line based, `environmentDefault` will make it the default for a given type in the entire environment.
-* `extensions.costReporting` - setting this field to true will enable cost reporting with this artifact (currently not supported in self-hosted).

--- a/definitions/artifacts/aws-iam-role.json
+++ b/definitions/artifacts/aws-iam-role.json
@@ -13,6 +13,7 @@
     "extensions": {
       "costReporting": true
     },
+    "defaultTargetConnectionGroup": "credentials",
     "ui": {
       "environmentDefaultGroup": "credentials",
       "connectionOrientation": "environmentDefault",

--- a/definitions/artifacts/aws-iam-role.json
+++ b/definitions/artifacts/aws-iam-role.json
@@ -2,7 +2,8 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
     "defaultTargetConnectionGroup": "credentials",
-    "defaultTargetConnectionGroupLabel": "AWS IAM Role",
+    "name": "aws-iam-role",
+    "label": "AWS IAM Role",
     "importing": {
       "group": "authentication"
     },
@@ -13,7 +14,6 @@
     "extensions": {
       "costReporting": true
     },
-    "name": "aws-iam-role",
     "ui": {
       "connectionOrientation": "environmentDefault",
       "instructions": [

--- a/definitions/artifacts/aws-iam-role.json
+++ b/definitions/artifacts/aws-iam-role.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "credentials",
     "name": "aws-iam-role",
     "label": "AWS IAM Role",
     "importing": {
@@ -15,6 +14,7 @@
       "costReporting": true
     },
     "ui": {
+      "environmentDefaultGroup": "credentials",
       "connectionOrientation": "environmentDefault",
       "instructions": [
         {

--- a/definitions/artifacts/aws-vpc.json
+++ b/definitions/artifacts/aws-vpc.json
@@ -1,7 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "networking",
+    "ui":{
+      "environmentDefaultGroup": "networking"
+    },
     "name": "aws-vpc",
     "label": "AWS VPC",
     "importing": {

--- a/definitions/artifacts/aws-vpc.json
+++ b/definitions/artifacts/aws-vpc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
+    "defaultTargetConnectionGroup": "networking",
     "ui":{
       "environmentDefaultGroup": "networking"
     },

--- a/definitions/artifacts/aws-vpc.json
+++ b/definitions/artifacts/aws-vpc.json
@@ -1,13 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-
     "defaultTargetConnectionGroup": "networking",
-    "defaultTargetConnectionGroupLabel": "AWS",
+    "name": "aws-vpc",
+    "label": "AWS VPC",
     "importing": {
       "group": "networking"
-    },
-    "name": "aws-vpc"
+    }
   },
   "type": "object",
   "title": "AWS Virtual Private Cloud",

--- a/definitions/artifacts/azure-service-principal.json
+++ b/definitions/artifacts/azure-service-principal.json
@@ -9,6 +9,7 @@
       "costReporting": true
     },
     "name": "azure-service-principal",
+    "defaultTargetConnectionGroup": "credentials",
     "ui": {
       "environmentDefaultGroup": "credentials",
       "connectionOrientation": "environmentDefault",

--- a/definitions/artifacts/azure-service-principal.json
+++ b/definitions/artifacts/azure-service-principal.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "credentials",
     "label": "Azure Service Principal",
     "importing": {
       "group": "authentication"
@@ -11,6 +10,7 @@
     },
     "name": "azure-service-principal",
     "ui": {
+      "environmentDefaultGroup": "credentials",
       "connectionOrientation": "environmentDefault",
       "instructions": [
         {

--- a/definitions/artifacts/azure-service-principal.json
+++ b/definitions/artifacts/azure-service-principal.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
     "defaultTargetConnectionGroup": "credentials",
-    "defaultTargetConnectionGroupLabel": "Azure Service Principal",
+    "label": "Azure Service Principal",
     "importing": {
       "group": "authentication"
     },

--- a/definitions/artifacts/azure-virtual-network.json
+++ b/definitions/artifacts/azure-virtual-network.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
+    "defaultTargetConnectionGroup": "networking",
     "ui": {
       "environmentDefaultGroup": "networking"
     },

--- a/definitions/artifacts/azure-virtual-network.json
+++ b/definitions/artifacts/azure-virtual-network.json
@@ -1,9 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-
     "defaultTargetConnectionGroup": "networking",
-    "defaultTargetConnectionGroupLabel": "Azure",
+    "label": "Azure VNet",
     "importing": {
       "group": "networking"
     },

--- a/definitions/artifacts/azure-virtual-network.json
+++ b/definitions/artifacts/azure-virtual-network.json
@@ -1,7 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "networking",
+    "ui": {
+      "environmentDefaultGroup": "networking"
+    },
     "label": "Azure VNet",
     "importing": {
       "group": "networking"

--- a/definitions/artifacts/gcp-service-account.json
+++ b/definitions/artifacts/gcp-service-account.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
     "defaultTargetConnectionGroup": "credentials",
-    "defaultTargetConnectionGroupLabel": "GCP Service Account",
+    "label": "GCP Service Account",
     "importing": {
       "fileUploadType": "json",
       "group": "authentication"

--- a/definitions/artifacts/gcp-service-account.json
+++ b/definitions/artifacts/gcp-service-account.json
@@ -11,6 +11,7 @@
       "cloud": "gcp"
     },
     "name": "gcp-service-account",
+    "defaultTargetConnectionGroup": "credentials",
     "ui": {
       "environmentDefaultGroup": "credentials",
       "connectionOrientation": "environmentDefault",

--- a/definitions/artifacts/gcp-service-account.json
+++ b/definitions/artifacts/gcp-service-account.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "credentials",
     "label": "GCP Service Account",
     "importing": {
       "fileUploadType": "json",
@@ -13,6 +12,7 @@
     },
     "name": "gcp-service-account",
     "ui": {
+      "environmentDefaultGroup": "credentials",
       "connectionOrientation": "environmentDefault",
       "instructions": [
         {

--- a/definitions/artifacts/gcp-subnetwork.json
+++ b/definitions/artifacts/gcp-subnetwork.json
@@ -1,9 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-
     "defaultTargetConnectionGroup": "networking",
-    "defaultTargetConnectionGroupLabel": "GCP",
+    "label": "GCP Subnetwork",
     "importing": {
       "group": "networking"
     },

--- a/definitions/artifacts/gcp-subnetwork.json
+++ b/definitions/artifacts/gcp-subnetwork.json
@@ -1,7 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "networking",
+    "ui": {
+      "environmentDefaultGroup": "networking"
+    },
     "label": "GCP Subnetwork",
     "importing": {
       "group": "networking"

--- a/definitions/artifacts/gcp-subnetwork.json
+++ b/definitions/artifacts/gcp-subnetwork.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
+    "defaultTargetConnectionGroup": "networking",
     "ui": {
       "environmentDefaultGroup": "networking"
     },

--- a/definitions/artifacts/kubernetes-cluster.json
+++ b/definitions/artifacts/kubernetes-cluster.json
@@ -1,9 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-
     "defaultTargetConnectionGroup": "credentials",
-    "defaultTargetConnectionGroupLabel": "Kubernetes Cluster",
+    "label": "Kubernetes Cluster",
     "export": [
       {
         "downloadButtonText": "Kube Config",

--- a/definitions/artifacts/kubernetes-cluster.json
+++ b/definitions/artifacts/kubernetes-cluster.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "credentials",
     "label": "Kubernetes Cluster",
     "export": [
       {
@@ -13,6 +12,7 @@
     ],
     "name": "kubernetes-cluster",
     "ui": {
+      "environmentDefaultGroup": "credentials",
       "instructions": [
         {
           "label": "kubectl CLI",

--- a/definitions/artifacts/kubernetes-cluster.json
+++ b/definitions/artifacts/kubernetes-cluster.json
@@ -11,6 +11,7 @@
       }
     ],
     "name": "kubernetes-cluster",
+    "defaultTargetConnectionGroup": "credentials",
     "ui": {
       "environmentDefaultGroup": "credentials",
       "instructions": [


### PR DESCRIPTION
Moves TDC to $md.label (all UI labels) and $md.ui.environmentDefaultGroup.

This will fully enable the customization of the canvas sidebar for end users.