### PR TITLE
drop defaultTargetConnectionGroup

### DIFF
--- a/definitions/artifacts/aws-iam-role.json
+++ b/definitions/artifacts/aws-iam-role.json
@@ -13,7 +13,6 @@
     "extensions": {
       "costReporting": true
     },
-    "defaultTargetConnectionGroup": "credentials",
     "ui": {
       "environmentDefaultGroup": "credentials",
       "connectionOrientation": "environmentDefault",

--- a/definitions/artifacts/aws-vpc.json
+++ b/definitions/artifacts/aws-vpc.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "networking",
     "ui":{
       "environmentDefaultGroup": "networking"
     },
+    "icon": "https://raw.githubusercontent.com/massdriver-cloud/icons/refs/heads/main/public/aws/virtual-private-cloud.svg",
     "name": "aws-vpc",
     "label": "AWS VPC",
     "importing": {

--- a/definitions/artifacts/azure-service-principal.json
+++ b/definitions/artifacts/azure-service-principal.json
@@ -9,7 +9,6 @@
       "costReporting": true
     },
     "name": "azure-service-principal",
-    "defaultTargetConnectionGroup": "credentials",
     "ui": {
       "environmentDefaultGroup": "credentials",
       "connectionOrientation": "environmentDefault",

--- a/definitions/artifacts/azure-virtual-network.json
+++ b/definitions/artifacts/azure-virtual-network.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "networking",
     "ui": {
       "environmentDefaultGroup": "networking"
     },

--- a/definitions/artifacts/gcp-service-account.json
+++ b/definitions/artifacts/gcp-service-account.json
@@ -11,7 +11,6 @@
       "cloud": "gcp"
     },
     "name": "gcp-service-account",
-    "defaultTargetConnectionGroup": "credentials",
     "ui": {
       "environmentDefaultGroup": "credentials",
       "connectionOrientation": "environmentDefault",

--- a/definitions/artifacts/gcp-subnetwork.json
+++ b/definitions/artifacts/gcp-subnetwork.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$md": {
-    "defaultTargetConnectionGroup": "networking",
     "ui": {
       "environmentDefaultGroup": "networking"
     },

--- a/definitions/artifacts/kubernetes-cluster.json
+++ b/definitions/artifacts/kubernetes-cluster.json
@@ -11,7 +11,6 @@
       }
     ],
     "name": "kubernetes-cluster",
-    "defaultTargetConnectionGroup": "credentials",
     "ui": {
       "environmentDefaultGroup": "credentials",
       "instructions": [


### PR DESCRIPTION
Finishes deprecation cycle and field migration for customizing the canvas defaults sidebar.